### PR TITLE
Fix help not showing

### DIFF
--- a/primehub/utils/argparser/__init__.py
+++ b/primehub/utils/argparser/__init__.py
@@ -87,27 +87,32 @@ class PrimeHubHelpFormatter(HelpFormatter):
         super(PrimeHubHelpFormatter, self).start_section(heading)
 
 
-def create_command_parser(description=None):
-    p = PrimeHubArgParser(formatter_class=PrimeHubHelpFormatter, add_help=False)
-    p.add_argument('command')
-    p.command_description = description
-
+def add_global_options(p):
     help_opts = p.add_argument_group('Options')
     help_opts.add_argument('-h', '--help', help='Show the help', action='store_true', default=False, dest='show_help')
-
     opts = p.add_argument_group('Global Options')
     opts.add_argument('--config', help='the path of the config file')
     opts.add_argument('--endpoint', help='the endpoint to the PrimeHub GraphQL URL')
     opts.add_argument('--token', help='API Token generated from PrimeHub Console')
     opts.add_argument('--group', help='override the active group')
 
+
+def create_command_parser(description=None):
+    p = PrimeHubArgParser(formatter_class=PrimeHubHelpFormatter, add_help=False)
+    p.add_argument('command')
+    p.command_description = description
+
+    add_global_options(p)
     return p
 
 
-def create_action_parser(description=None):
+def create_action_parser(group_command, description=None):
     p = PrimeHubArgParser(formatter_class=PrimeHubHelpFormatter, add_help=False)
+    p.usage = 'primehub {} [command]'.format(group_command)
     p.add_argument('command')
-    p.command_description = ""
+    p.command_description = description
+
+    add_global_options(p)
     return p
 
 

--- a/tests/test_sdk_to_cli.py
+++ b/tests/test_sdk_to_cli.py
@@ -39,6 +39,9 @@ class TestCommandGroupToCommandLine(BaseTestCase):
         # clean commands, add the FakeCommand
         self.sdk.register_command('test_sdk_to_cli', FakeCommand)
 
+    def fake(self) -> FakeCommand:
+        return FakeCommand(self.sdk)
+
     def test_command_groups(self):
         output = self.cli_stderr(['app.py', '-h'])
 
@@ -50,13 +53,8 @@ class TestCommandGroupToCommandLine(BaseTestCase):
         self.assertTrue(description in c[0], 'We should find the help messages in the output')
 
     def test_action_help(self):
-        # output = self.cli_stderr(['app.py', 'test_sdk_to_cli', '-h'])
-        # TODO it will fail, not implemented it
-        # self.assertTrue('action_no_args' in output)
-        pass
-
-    def fake(self) -> FakeCommand:
-        return FakeCommand(self.sdk)
+        output = self.cli_stderr(['app.py', 'test_sdk_to_cli', '-h'])
+        self.assertTrue('action_no_args' in output)
 
     def test_action_no_args(self):
         output = self.cli_stdout(['app.py', 'test_sdk_to_cli', 'cmd-no-args'])


### PR DESCRIPTION
In some case, the second level command doesn't show help message with `-h`. This PR fixes the problem.