### PR TITLE
Add optional arguments and typing support

### DIFF
--- a/primehub/utils/decorators.py
+++ b/primehub/utils/decorators.py
@@ -74,7 +74,16 @@ def cmd(**cmd_args):
         # TODO only generate references when invoked from primehub-cli
         cmd_args['func'] = func.__name__
         sig = signature(func)
-        cmd_args['arguments'] = [x.name for x in sig.parameters.values() if x.name != 'self']
+        import inspect
+
+        def info(x):
+            if x.annotation is inspect.Parameter.empty:
+                t = str
+            else:
+                t = x.annotation
+            return x.name, t, str(x.kind) == 'VAR_KEYWORD',
+
+        cmd_args['arguments'] = [info(x) for x in sig.parameters.values() if x.name != 'self']
         logger.debug("cmd -> %s", cmd_args)
         register_to_command_group(func, cmd_args)
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -5,6 +5,9 @@ import os
 from unittest import TestCase, mock
 
 from primehub import PrimeHub, PrimeHubConfig, cli
+from primehub.utils import create_logger
+
+logger = create_logger('primehub-test')
 
 
 def reset_stderr_stdout(func):
@@ -47,25 +50,30 @@ class BaseTestCase(TestCase):
 
     @reset_stderr_stdout
     def cli_stderr(self, argv: list):
-        try:
-            import sys
-            sys.argv = argv
-            cli.main(sdk=self.sdk)
-        except SystemExit:
-            pass
+        print("cli_stderr", argv)
+        self.invoke_cli(argv)
         return self.sdk.stderr.getvalue()
 
     @reset_stderr_stdout
     def cli_stdout(self, argv: list):
+        print("cli_stdout", argv)
+        self.invoke_cli(argv)
+        return self.sdk.stdout.getvalue()
+
+    def invoke_cli(self, argv):
         try:
             import sys
             sys.argv = argv
+            if [x for x in argv if not isinstance(x, str)]:
+                raise ValueError('all arguments must be a str type')
             cli.main(sdk=self.sdk)
         except SystemExit:
             pass
-        return self.sdk.stdout.getvalue()
 
     def reset_cli_output(self):
+        logger.info("\n{} reset_cli_output {}".format("=" * 40, "=" * 40))
+        logger.info("\nSTDOUT:\n\n{}\n\nSTDERR:\n\n{}\n\n".format(self.sdk.stdout.getvalue(),
+                                                                  self.sdk.stderr.getvalue()))
         self.sdk.stderr = io.StringIO()
         self.sdk.stdout = io.StringIO()
 


### PR DESCRIPTION

Implement typing in `@cmd` and `optionals`, see the tests `test_sdk_to_cli.py`

If arg with type annotation, the argparse will convert it to proper type:

```python
@cmd(name='cmd-arg-str-int', description='action_str_int_args')
def action_arg_str_int(self, arg1: str, arg2: int):
    pass
```

It also works with optionals by a tuple with the `(name, type)` pair

```python
@cmd(name='cmd-args-opts', description='action_optional_args', optionals=[('arg2', str), ('page', int)])
def action_optional_args(self, arg1: str, **kwargs):
    pass
```