### PR TITLE
check group info before set-group command done

### DIFF
--- a/primehub/cli.py
+++ b/primehub/cli.py
@@ -7,7 +7,7 @@ from primehub.utils.decorators import find_actions, find_action_method, find_act
 
 import sys
 
-from primehub.utils import create_logger
+from primehub.utils import create_logger, PrimeHubException
 
 logger = create_logger('primehub-cli')
 
@@ -184,6 +184,7 @@ def main(sdk=None):
 
     command_groups = create_commands(main_parser, sdk)
 
+    hide_help = False
     helper = None
     exit_normally = False
     try:
@@ -218,11 +219,17 @@ def main(sdk=None):
 
         if helper:
             sys.exit(1)
+    except PrimeHubException as e:
+        hide_help = True
+        exit_normally = False
+        print(e, file=sdk.stderr)
+        sys.exit(1)
     except SystemExit:
-        if helper:
-            helper.print_help(file=sdk.stderr)
-        else:
-            main_parser.print_help(file=sdk.stderr)
+        if not hide_help:
+            if helper:
+                helper.print_help(file=sdk.stderr)
+            else:
+                main_parser.print_help(file=sdk.stderr)
 
         if exit_normally:
             sys.exit(0)

--- a/primehub/config.py
+++ b/primehub/config.py
@@ -1,4 +1,4 @@
-from primehub.utils import create_logger
+from primehub.utils import create_logger, group_not_found
 
 from primehub import Helpful, cmd, Module
 
@@ -21,7 +21,7 @@ class Config(Helpful, Module):
         try:
             selected_group = self._fetch_group_info(group)
             if selected_group is None:
-                logger.warning('Cannot find the group [%s] in the effective groups', group)
+                logger.info('Cannot find the group [%s] in the effective groups', group)
             else:
                 self.primehub.primehub_config.current_group = selected_group
         except BaseException as e:
@@ -64,6 +64,10 @@ class CliConfig(Config):
     @cmd(name='set-group', description='set group and save to the config file')
     def set_group(self, group: str):
         super(CliConfig, self).set_group(group)
+        if not self.primehub.primehub_config.group_info:
+            group_not_found(group)
+        if not self.primehub.primehub_config.group_info.get('id', None):
+            group_not_found(group)
         self.update()
 
     def update(self):

--- a/primehub/utils/__init__.py
+++ b/primehub/utils/__init__.py
@@ -7,12 +7,16 @@ class PrimeHubException(BaseException):
     pass
 
 
-class GroupIsRequiredException(BaseException):
+class GroupIsRequiredException(PrimeHubException):
     pass
 
 
 def group_required():
     raise GroupIsRequiredException('No group information, please configure the active group first.')
+
+
+def group_not_found(group):
+    raise GroupIsRequiredException('No group information for [%s], please set the right group' % group)
 
 
 def create_logger(name) -> logging.Logger:


### PR DESCRIPTION

Show errors and stop updating the config file and exit with `1`

```
No group information for [xxx], please set the right group
```