### PR TITLE
Fix arg parser skipping optionals bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+default: test-html
+
+
 dev-requires:
 	pip install -e .[dev]
 

--- a/primehub/cli.py
+++ b/primehub/cli.py
@@ -83,10 +83,10 @@ def run_action_args(sdk, selected_component, sub_parsers, target, remaining_args
             if skip_if_kwargs:
                 # we will add optional argument in the next step
                 # convert it to `--<arg-name>` format
+                has_kwargs = True
                 continue
             action_parser.add_argument(param_name, type=param_type)
             argument_names.append(param_name)
-            has_kwargs = True
 
         # @cmd with empty optionals, skip the kwargs handling
         if not action['optionals']:
@@ -98,9 +98,6 @@ def run_action_args(sdk, selected_component, sub_parsers, target, remaining_args
 
         try:
             parsed_action_args = action_parser.parse_args([sub_args.command] + params)
-            # logger.debug('parsed_action_args: %s # %s', parsed_action_args, unknown)
-            # if unknown:
-            #     sys.exit(0)
 
             # invoke <command_group>.<action>(param1, param2, ...) from the register command
             action_func = action['func']

--- a/primehub/utils/argparser/__init__.py
+++ b/primehub/utils/argparser/__init__.py
@@ -3,7 +3,11 @@ import sys
 from argparse import ArgumentParser, HelpFormatter, Action
 from typing import Text, Iterable, Optional
 
+from primehub.utils import create_logger
+
 PhArgGroupClass = getattr(importlib.import_module('argparse'), '_ArgumentGroup')
+
+logger = create_logger('primehub-parser')
 
 
 class PrimeHubArgParser(ArgumentParser):
@@ -18,6 +22,8 @@ class PrimeHubArgParser(ArgumentParser):
         If you override this in a subclass, it should not return -- it
         should either exit or raise an exception.
         """
+
+        logger.debug('errors: %s', message)
 
         # NOTE: we print usage at cli.py module
         # self.print_usage(sys.stderr)

--- a/tests/test_sdk_to_cli.py
+++ b/tests/test_sdk_to_cli.py
@@ -28,6 +28,10 @@ class FakeCommand(Helpful, Module):
             result['page'] = kwargs['page']
         return result
 
+    @cmd(name='cmd-only-opts', description='action_only_optionals', optionals=[('file', str)])
+    def action_only_optionals(self, **kwargs):
+        return kwargs
+
     def help_description(self):
         return "help message for fake-command"
 
@@ -78,3 +82,7 @@ class TestCommandGroupToCommandLine(BaseTestCase):
 
         output = self.cli_stdout(['app.py', 'test_sdk_to_cli', 'cmd-args-opts', 'arg1', '--page', '9527'])
         self.assertEqual(json.dumps(self.fake().action_optional_args('arg1', page=9527)), output.strip())
+
+    def test_action_with_only_optionals(self):
+        output = self.cli_stdout(['app.py', 'test_sdk_to_cli', 'cmd-only-opts', '--file', 'filename'])
+        self.assertEqual(json.dumps(self.fake().action_only_optionals(file='filename')), output.strip())


### PR DESCRIPTION

We got a bug in this case:

```python
    @cmd(name='cmd-only-opts', description='action_only_optionals', optionals=[('file', str)])
    def action_only_optionals(self, **kwargs):
        return kwargs
```

The bug was that: any `@cmd` without required arguments would not process optional variables.