### PR TITLE
Introduce @ask_for_permission

### DIFF
--- a/primehub/devlab.py
+++ b/primehub/devlab.py
@@ -1,6 +1,7 @@
 import sys
 
 from primehub import Helpful, cmd, has_data_from_stdin, Module
+from primehub.utils.permission import ask_for_permission
 
 
 class DevLab(Helpful, Module):
@@ -46,6 +47,16 @@ class DevLab(Helpful, Module):
         """
         results = self.request({}, query)
         return results['data']['me']['effectiveGroups']
+
+    @ask_for_permission
+    @cmd(name='say-yes', description='show case for @ask_for_permission')
+    def ask_for_permission(self, **kwargs):
+        from datetime import datetime
+        s = str(datetime.now())
+        with open("ask_for_permission.txt", "w") as fh:
+            fh.write(s)
+            fh.write("\n")
+        return dict(message='create a file [ask_for_permission.txt] having the current datetime content')
 
     def help(self):
         return "help me"

--- a/primehub/utils/__init__.py
+++ b/primehub/utils/__init__.py
@@ -11,6 +11,15 @@ class GroupIsRequiredException(PrimeHubException):
     pass
 
 
+class UserRejectAction(PrimeHubException):
+    pass
+
+
+def reject_action(action):
+    raise UserRejectAction(
+        'User rejects action [%s], please use the flag "--yes-i-really-mean-it" to allow the action.' % action)
+
+
 def group_required():
     raise GroupIsRequiredException('No group information, please configure the active group first.')
 

--- a/primehub/utils/decorators.py
+++ b/primehub/utils/decorators.py
@@ -8,6 +8,7 @@ logger = create_logger('decorator')
 
 __command_groups__: Dict[str, list] = dict()
 __actions__: Dict[str, dict] = dict()
+__requires_permission__: Dict[str, str] = dict()
 
 
 def find_actions(sub_command):
@@ -72,6 +73,7 @@ def cmd(**cmd_args):
 
     def make_command_references(func):
         # TODO only generate references when invoked from primehub-cli
+        cmd_args['module'] = func.__module__
         cmd_args['func'] = func.__name__
         sig = signature(func)
         import inspect

--- a/primehub/utils/permission.py
+++ b/primehub/utils/permission.py
@@ -1,0 +1,46 @@
+from functools import wraps
+
+from primehub.utils import reject_action
+from primehub.utils.decorators import __requires_permission__, logger, __command_groups__
+
+
+def has_permission_flag(cmd_args: dict):
+    k = "{}.{}".format(cmd_args['module'], cmd_args['func'])
+    if k in __requires_permission__:
+        return True
+    return False
+
+
+def disable_reject_action(action):
+    logger.debug('@ask_for_permission is disable, the action will pass %s', action)
+
+
+reject_action_function = disable_reject_action
+
+
+def enable_ask_for_permission_feature():
+    global reject_action_function
+    reject_action_function = reject_action
+
+
+def ask_for_permission(func):
+    k = "{}.{}".format(func.__module__, func.__name__)
+    __requires_permission__[k] = ""
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        if not kwargs.get('--yes-i-really-mean-it', False):
+            cmd_args = None
+            try:
+                actions = __command_groups__[func.__module__]
+                cmd_args = [x for x in actions if x['func'] == func.__name__]
+            except BaseException:
+                pass
+            if cmd_args:
+                reject_action_function(cmd_args[0]['name'])
+            else:
+                reject_action_function(func.__name__)
+
+        return func(*args, **kwargs)
+
+    return wrapper


### PR DESCRIPTION
Developers could use `@ask_for_permission` to ask permission from the command line user, for example:

```python
@ask_for_permission
@cmd(name='say-yes', description='show case for @ask_for_permission')
def ask_for_permission(self, **kwargs):
    from datetime import datetime
    s = str(datetime.now())
    with open("ask_for_permission.txt", "w") as fh:
        fh.write(s)
        fh.write("\n")
    return dict(message='create a file [ask_for_permission.txt] having the current datetime content')
```

1. decorate the method with `@ask_for_permission` and `@cmd`
2. provider the kwargs

----

## Use case

```bash
$ PRIMEHUB_SDK_DEVLAB=true primehub devlab say-yes
User rejects action [say-yes], please use the flag "--yes-i-really-mean-it" to allow the action.
```

```bash
$ PRIMEHUB_SDK_DEVLAB=true primehub devlab say-yes --yes-i-really-mean-it
{"message": "create a file [ask_for_permission.txt] having the current datetime content"}
```

## Note for Cli/SDK

* the feature enables in the command line mode by `enable_ask_for_permission_feature()`.
* SDK will have the default behavior without asking for permission