### PR TITLE
Group context support

### DIFF
--- a/primehub/__init__.py
+++ b/primehub/__init__.py
@@ -278,7 +278,9 @@ class Module(object):
 
     @property
     def primehub_config(self):
-        raise ValueError('primehub_config is access denied')
+        raise ValueError(
+            'The attribute [primehub_config] is access denied, '
+            'please use props of the Module to get configurations')
 
 
 def has_data_from_stdin():

--- a/primehub/__init__.py
+++ b/primehub/__init__.py
@@ -273,6 +273,10 @@ class Module(object):
         return self.current_group['name']
 
     @property
+    def endpoint(self) -> str:
+        return self.primehub.primehub_config.endpoint
+
+    @property
     def primehub_config(self):
         raise ValueError('primehub_config is access denied')
 

--- a/primehub/__init__.py
+++ b/primehub/__init__.py
@@ -5,6 +5,7 @@ import os
 import sys
 from typing import Union, Callable, Dict
 
+from primehub.utils import group_required
 from primehub.utils.decorators import cmd  # noqa: F401
 from primehub.utils.http_client import Client
 
@@ -146,12 +147,12 @@ class PrimeHubConfig(object):
             self.config_from_user_input['endpoint'] = endpoint
 
     @property
-    def current_group(self):
+    def current_group(self) -> dict:
         return self.group_info
 
     @current_group.setter
     def current_group(self, group_info):
-        if group_info:
+        if group_info and group_info.get('id', None):
             self.group_info = group_info
 
 
@@ -223,7 +224,6 @@ class PrimeHub(object):
         cmd_group = self.commands[command_name] = clazz(self)
 
         # attach request method
-        cmd_group.primehub_config = self.primehub_config
         cmd_group.request = self.request
         cmd_group.request_logs = self.request_logs
         cmd_group.request_file = self.request_file
@@ -254,6 +254,27 @@ class Module(object):
 
     def __init__(self, primehub: PrimeHub, **kwargs):
         self.primehub = primehub
+
+    @property
+    def current_group(self) -> dict:
+        g = self.primehub.primehub_config.current_group
+        if not g:
+            group_required()
+        if not g.get('id', None):
+            group_required()
+        return g
+
+    @property
+    def group_id(self) -> str:
+        return self.current_group['id']
+
+    @property
+    def group_name(self) -> str:
+        return self.current_group['name']
+
+    @property
+    def primehub_config(self):
+        raise ValueError('primehub_config is access denied')
 
 
 def has_data_from_stdin():

--- a/primehub/files.py
+++ b/primehub/files.py
@@ -26,14 +26,14 @@ class Files(Helpful, Module):
     # TODO: handel path or dest does not exist
     @cmd(name='download', description='Download shared files', optionals=[('recursive', bool)])
     def download(self, path, dest, **kwargs):
-        u = urlparse(self.primehub_config.endpoint)
-        endpoint = u._replace(path='/api/files/groups/' + self.primehub_config.group_info['name']).geturl()
+        u = urlparse(self.endpoint)
+        endpoint = u._replace(path='/api/files/groups/' + self.group_name).geturl()
 
         if dest[-1] != '/':
             dest = dest + '/'
 
         if kwargs.get('recursive', False):
-            if path[-1] != '/':     # avoid files and directories with the same prefix
+            if path[-1] != '/':  # avoid files and directories with the same prefix
                 path = path + '/'
             dirname = os.path.dirname(path[:-1])
             dirs = [path]
@@ -43,9 +43,9 @@ class Files(Helpful, Module):
                 for dir in dirs:
                     for file in self.list(dir):
                         p = dir + file['name']
-                        if p[-1] == '/':   # folder
+                        if p[-1] == '/':  # folder
                             sub_dirs.append(p)
-                        else:              # file
+                        else:  # file
                             self.request_file(endpoint + path + p, dest + p[len(dirname):])
                 dirs = sub_dirs
             return

--- a/primehub/info.py
+++ b/primehub/info.py
@@ -3,20 +3,18 @@ from primehub import Helpful, cmd, Module
 
 class CliInformation(Helpful, Module):
 
-    # TODO we should support group-context aware
-    # TODO create a decorator @group_required
     @cmd(name='info', description='Show PrimeHub Cli information')
     def info(self):
         me = self.primehub.me.me()
         me['user_id'] = me['id']
 
-        current_group = self.primehub.group.get(self.primehub.primehub_config.group)
+        current_group = self.primehub.group.get(self.group_name)
         images = [x['name'] for x in current_group['images']]
         instance_types = [x['name'] for x in current_group['instanceTypes']]
         datasets = [x['name'] for x in current_group['datasets']]
 
         if not current_group:
-            group_status = " (No matched group for name %s)" % self.primehub.primehub_config.group
+            group_status = " (No matched group for name %s)" % self.group_name
         else:
             group_status = """
   Id: %(id)s
@@ -35,7 +33,7 @@ class CliInformation(Helpful, Module):
         def indent2(lines):
             return "\n  ".join(lines)
 
-        args = dict(endpoint=self.primehub.primehub_config.endpoint, group_status=group_status.strip(),
+        args = dict(endpoint=self.endpoint, group_status=group_status.strip(),
                     images=indent2(images), instance_types=indent2(instance_types), datasets=indent2(datasets))
         output = """Endpoint: %(endpoint)s
 User:

--- a/primehub/jobs.py
+++ b/primehub/jobs.py
@@ -53,7 +53,7 @@ class Jobs(Helpful, Module):
         """
         variables = {
             'where': {
-                'groupId_in': [self.primehub_config.group_info['id']]
+                'groupId_in': [self.group_id]
             },
             'page': 1
         }
@@ -153,7 +153,7 @@ class Jobs(Helpful, Module):
             if os.path.exists(filename):
                 with open(filename, 'r') as fh:
                     data = json.load(fh)
-        data['groupId'] = self.primehub_config.group_info['id']
+        data['groupId'] = self.group_id
         results = self.request({'data': data}, query)
         return results['data']['createPhJob']
 
@@ -280,7 +280,7 @@ class Jobs(Helpful, Module):
     @cmd(name='download-artifacts', description='Download artifacts', optionals=[('recursive', bool)])
     def download_artifacts(self, id, path, dest, **kwargs):
         artifacts = self.list_artifacts(id)
-        u = urlparse(self.primehub_config.endpoint)
+        u = urlparse(self.endpoint)
         endpoint = u._replace(path='/api/files/' + artifacts['prefix'] + '/').geturl()
 
         if dest[-1] != '/':

--- a/primehub/notebooks.py
+++ b/primehub/notebooks.py
@@ -11,7 +11,7 @@ class Notebooks(Helpful, Module):
         follow = kwargs.get('follow', False)
         tail = kwargs.get('tail', 10)
 
-        endpoint = urllib.parse.urljoin(self.primehub.primehub_config.endpoint, '/api/logs/jupyterhub')
+        endpoint = urllib.parse.urljoin(self.endpoint, '/api/logs/jupyterhub')
         return self.primehub.request_logs(endpoint, follow, tail)
 
     def help_description(self):

--- a/primehub/resource_operations.py
+++ b/primehub/resource_operations.py
@@ -1,15 +1,11 @@
-from primehub.utils import group_required
-
-
 class GroupResourceOperation(object):
 
     def do_list(self, query, resource_key):
-        if not self.primehub_config.group_info:
-            group_required()
+        current_group = self.group_name
 
         results = self.request({}, query)
         for g in results['data']['me']['effectiveGroups']:
-            if self.primehub_config.group_info['name'] == g['name']:
+            if current_group == g['name']:
                 return g[resource_key]
         return []
 

--- a/primehub/schedules.py
+++ b/primehub/schedules.py
@@ -49,7 +49,7 @@ class Schedules(Helpful, Module):
         """
         variables = {
           'where': {
-            'groupId_in': [self.primehub_config.group_info['id']]
+            'groupId_in': [self.group_id]
           },
           'page': 1
         }
@@ -144,7 +144,7 @@ class Schedules(Helpful, Module):
             if os.path.exists(filename):
                 with open(filename, 'r') as fh:
                     data = json.load(fh)
-        data['groupId'] = self.primehub_config.group_info['id']
+        data['groupId'] = self.group_id
         results = self.request({'data': data}, query)
         return results['data']['createPhSchedule']
 
@@ -190,7 +190,7 @@ class Schedules(Helpful, Module):
             if os.path.exists(filename):
                 with open(filename, 'r') as fh:
                     data = json.load(fh)
-        data['groupId'] = self.primehub_config.group_info['id']
+        data['groupId'] = self.group_id
         results = self.request({'data': data, 'where': {'id': id}}, query)
         return results['data']['updatePhSchedule']
 

--- a/tests/test_group_resource_operation.py
+++ b/tests/test_group_resource_operation.py
@@ -30,7 +30,7 @@ class TestGroupResourceOperation(BaseTestCase):
         self.assertEqual('No group information, please configure the active group first.', output.strip())
 
     def test_group_resource_operation(self):
-        self.sdk.primehub_config.group_info = {'name': 'phusers'}
+        self.sdk.primehub_config.group_info = {'name': 'phusers', 'id': 'any-id'}
         self.mock_request.return_value = {
             'data': {
                 'me': {


### PR DESCRIPTION
Some commands require `group` information to filter results. If the current group is not configured correctly, SDK should show errors to the caller.

## Changes

* the `command.primehub_config` will be denied from a command
* export group information properties

```python
class Module(object):

    # ... skip ...

    @property
    def current_group(self) -> dict:
        g = self.primehub.primehub_config.current_group
        if not g:
            group_required()
        if not g.get('id', None):
            group_required()
        return g

    @property
    def group_id(self) -> str:
        return self.current_group['id']

    @property
    def group_name(self) -> str:
        return self.current_group['name']

    @property
    def endpoint(self) -> str:
        return self.primehub.primehub_config.endpoint

    @property
    def primehub_config(self):
        raise ValueError(
            'The attribute [primehub_config] is access denied, '
            'please use props of the Module to get configurations')
```

All group information comes from `current_group` and it will raise an exception (`group_required()`) when the current not configured correctly.

