### PR TITLE
Add arg_builder for optional arguments

### DIFF
--- a/primehub/cli.py
+++ b/primehub/cli.py
@@ -90,8 +90,11 @@ def run_action_args(sdk, selected_component, sub_parsers, target, remaining_args
 
         # @cmd with optionals
         for x in action['optionals']:
-            opt_name, opt_type = x
-            action_parser.add_argument("--" + opt_name, type=opt_type)
+            # There is a tuple (x, y, z, ..., arg_builder) for each optional
+            # We use the arg_builder to create a new argument
+            arg_builder = x[-1]
+            arg_builder_args = [action_parser] + list(x[0:-1])
+            arg_builder(*arg_builder_args)
 
         # @ask_for_permission
         if has_permission_flag(action):
@@ -121,7 +124,7 @@ def run_action_args(sdk, selected_component, sub_parsers, target, remaining_args
             kw_parameters = {}
             if has_kwargs:
                 for x in action['optionals']:
-                    opt_name, opt_type = x
+                    opt_name = x[0]
                     v = getattr(parsed_action_args, opt_name)
                     if v is not None:
                         kw_parameters[opt_name] = v

--- a/primehub/files.py
+++ b/primehub/files.py
@@ -2,6 +2,8 @@ from primehub import Helpful, cmd, Module
 from urllib.parse import urlparse
 import os
 
+from primehub.utils.optionals import toggle_flag
+
 
 class Files(Helpful, Module):
     """
@@ -36,7 +38,7 @@ class Files(Helpful, Module):
         return results['data']['files']['items']
 
     # TODO: handel path or dest does not exist
-    @cmd(name='download', description='Download shared files', optionals=[('recursive', bool)])
+    @cmd(name='download', description='Download shared files', optionals=[('recursive', toggle_flag)])
     def download(self, path, dest, **kwargs):
         """
         Download files

--- a/primehub/jobs.py
+++ b/primehub/jobs.py
@@ -7,6 +7,8 @@ import json
 import sys
 from urllib.parse import urlparse
 
+from primehub.utils.optionals import toggle_flag
+
 
 class Jobs(Helpful, Module):
     """
@@ -395,7 +397,7 @@ class Jobs(Helpful, Module):
         return results['data']['phJob']['artifact']
 
     # TODO: handel path or dest does not exist
-    @cmd(name='download-artifacts', description='Download artifacts', optionals=[('recursive', bool)])
+    @cmd(name='download-artifacts', description='Download artifacts', optionals=[('recursive', toggle_flag)])
     def download_artifacts(self, id, path, dest, **kwargs):
         """
         Download job artifacts
@@ -420,7 +422,7 @@ class Jobs(Helpful, Module):
             dest = dest + '/'
 
         if kwargs.get('recursive', False):
-            if path[-1] != '/':     # avoid files or directories with the same prefix
+            if path[-1] != '/':  # avoid files or directories with the same prefix
                 path = path + '/'
             dirname = os.path.dirname(path[:-1])
             paths = [e['name'] for e in artifacts['items'] if e['name'].startswith(path)]

--- a/primehub/utils/decorators.py
+++ b/primehub/utils/decorators.py
@@ -1,8 +1,10 @@
 from functools import wraps
 from inspect import signature
+from types import FunctionType
 from typing import Dict
 
 from primehub.utils import create_logger
+from primehub.utils.optionals import default_optional_builder
 
 logger = create_logger('decorator')
 
@@ -63,6 +65,11 @@ def cmd(**cmd_args):
         raise ValueError('name description is required')
     if 'optionals' not in cmd_args:
         cmd_args['optionals'] = []
+
+    for idx, opts in enumerate(cmd_args['optionals']):
+        maybe_builder = opts[-1]
+        if not isinstance(maybe_builder, FunctionType):
+            cmd_args['optionals'][idx] = tuple(list(opts) + [default_optional_builder])
 
     def inner(func):
         make_command_references(func)

--- a/primehub/utils/optionals.py
+++ b/primehub/utils/optionals.py
@@ -1,0 +1,9 @@
+from argparse import ArgumentParser
+
+
+def default_optional_builder(parser: ArgumentParser, name: str, type_of_arg: type):
+    parser.add_argument("--" + name, type=type_of_arg)
+
+
+def toggle_flag(parser: ArgumentParser, name: str):
+    parser.add_argument("--" + name, action="store_true", default=False)

--- a/tests/test_sdk_to_cli.py
+++ b/tests/test_sdk_to_cli.py
@@ -2,6 +2,7 @@ import json
 import os
 
 from primehub import Helpful, Module, cmd
+from primehub.utils.optionals import toggle_flag
 from primehub.utils.permission import ask_for_permission
 from tests import BaseTestCase
 
@@ -51,6 +52,11 @@ class FakeCommand(Helpful, Module):
     def action_in_danger_no_arg_type_2(self, **kwargs):
         os.unlink("test_ask_for_permission_no_arg_type2.txt")
         return dict(result=True)
+
+    @cmd(name='recursive-toggle-flag', description='the action has a toggle flag',
+         optionals=[('recursive', toggle_flag)])
+    def action_toggle_flag(self, **kwargs):
+        return kwargs
 
     def help_description(self):
         return "help message for fake-command"
@@ -145,3 +151,10 @@ class TestCommandGroupToCommandLine(BaseTestCase):
         # the file will be removed by the flag `--yes-i-really-mean-it`
         self.cli_stdout(['app.py', 'test_sdk_to_cli', 'cmd-remove-it-no-arg-type-2', '--yes-i-really-mean-it'])
         self.assertFalse(os.path.exists(file_path_to_delete))
+
+    def test_toggle_flag(self):
+        output = self.cli_stdout(['app.py', 'test_sdk_to_cli', 'recursive-toggle-flag', '--recursive'])
+        self.assertEqual(dict(recursive=True), json.loads(output))
+
+        output = self.cli_stdout(['app.py', 'test_sdk_to_cli', 'recursive-toggle-flag'])
+        self.assertEqual(dict(recursive=False), json.loads(output))


### PR DESCRIPTION
## Introduce the optional argument builder

Developers could put a callback function to an optional, it will take the original parser and remaining optional configurations.

```py
    @cmd(name='download', description='Download shared files', optionals=[('recursive', toggle_flag)])
    def download(self, path, dest, **kwargs):
        pass
```

The `recursive` will pass to `toggle_flag` function

```py
def toggle_flag(parser: ArgumentParser, name: str):
    parser.add_argument("--" + name, action="store_true", default=False)
```


### Optional updates

* files download `--recursive` toggle
* jobs download `--recursive` toggle
