### PR TITLE
Introduce return_required to @cmd

### DIFF
--- a/primehub/cli.py
+++ b/primehub/cli.py
@@ -270,7 +270,7 @@ def main(sdk=None):
         else:
             sys.exit(1)
 
-    # exit application normal
+    # exit application normally
     sys.exit(0)
 
 

--- a/primehub/cli.py
+++ b/primehub/cli.py
@@ -9,7 +9,7 @@ from primehub.utils.permission import has_permission_flag, enable_ask_for_permis
 
 import sys
 
-from primehub.utils import create_logger, PrimeHubException
+from primehub.utils import create_logger, PrimeHubException, PrimeHubReturnsRequiredException
 
 logger = create_logger('primehub-cli')
 
@@ -145,6 +145,9 @@ def run_action_args(sdk, selected_component, sub_parsers, target, remaining_args
                     output(sdk, json.dumps(return_value))
                 else:
                     output(sdk, return_value)
+            else:
+                if action['return_required']:
+                    raise PrimeHubReturnsRequiredException()
         except SystemExit:
             return action_parser
 
@@ -180,6 +183,9 @@ def run_action_noargs(sdk, selected_component, sub_parsers, target, args):
                 output(sdk, json.dumps(return_value))
             else:
                 output(sdk, return_value)
+        else:
+            if action['return_required']:
+                raise PrimeHubReturnsRequiredException()
     except AttributeError:
         logger.debug('{}'.format(sys.exc_info()))
         helper = sub_parsers[selected_component]
@@ -241,6 +247,12 @@ def main(sdk=None):
 
         if helper:
             sys.exit(1)
+
+    except PrimeHubReturnsRequiredException:
+        logger.debug('got PrimeHubReturnsRequiredException')
+        hide_help = True
+        exit_normally = False
+        sys.exit(1)
     except PrimeHubException as e:
         hide_help = True
         exit_normally = False
@@ -257,6 +269,9 @@ def main(sdk=None):
             sys.exit(0)
         else:
             sys.exit(1)
+
+    # exit application normal
+    sys.exit(0)
 
 
 def reconfigure_primehub_config_if_needed(args, sdk):

--- a/primehub/datasets.py
+++ b/primehub/datasets.py
@@ -36,7 +36,7 @@ class Datasets(Helpful, Module, GroupResourceOperation):
         """
         return self.do_list(Datasets.query, Datasets.resource_name)
 
-    @cmd(name='get', description='Get a dataset by name')
+    @cmd(name='get', description='Get a dataset by name', return_required=True)
     def get(self, name) -> Optional[dict]:
         """
         Get a dataset from the current group

--- a/primehub/deployments.py
+++ b/primehub/deployments.py
@@ -63,7 +63,7 @@ class Deployments(Helpful, Module):
         results = self.request({'where': {'groupId_in': [self.group_id]}}, query)
         return results['data']['phDeployments']
 
-    @cmd(name='get', description='Get a deployment by id')
+    @cmd(name='get', description='Get a deployment by id', return_required=True)
     def get(self, id):
         """
         Get detail information of a deployment by id

--- a/primehub/groups.py
+++ b/primehub/groups.py
@@ -38,7 +38,7 @@ class Groups(Helpful, Module):
         results = self.request({}, query)
         return results['data']['me']['effectiveGroups']
 
-    @cmd(name='get', description='Get group by name')
+    @cmd(name='get', description='Get group by name', return_required=True)
     def get(self, group_name: str) -> Optional[dict]:
         """
         Get a group from available groups

--- a/primehub/images.py
+++ b/primehub/images.py
@@ -37,7 +37,7 @@ class Images(Helpful, Module, GroupResourceOperation):
         """
         return self.do_list(Images.query, Images.resource_name)
 
-    @cmd(name='get', description='Get a image by name')
+    @cmd(name='get', description='Get a image by name', return_required=True)
     def get(self, name) -> Optional[dict]:
         """
         Get an image from the current group

--- a/primehub/instancetypes.py
+++ b/primehub/instancetypes.py
@@ -35,7 +35,7 @@ class InstanceTypes(Helpful, Module, GroupResourceOperation):
         """
         return self.do_list(InstanceTypes.query, InstanceTypes.resource_name)
 
-    @cmd(name='get', description='Get an instance type by name')
+    @cmd(name='get', description='Get an instance type by name', return_required=True)
     def get(self, name) -> Optional[dict]:
         """
         Get an instance type from the current group

--- a/primehub/jobs.py
+++ b/primehub/jobs.py
@@ -94,7 +94,7 @@ class Jobs(Helpful, Module):
                 break
         return edges
 
-    @cmd(name='get', description='Get a job by id')
+    @cmd(name='get', description='Get a job by id', return_required=True)
     def get(self, id):
         """
         Get detail information of a job by id

--- a/primehub/me.py
+++ b/primehub/me.py
@@ -3,7 +3,7 @@ from primehub import Helpful, cmd, Module
 
 class Me(Helpful, Module):
 
-    @cmd(name='me', description='Get user information')
+    @cmd(name='me', description='Get user information', return_required=True)
     def me(self) -> dict:
         """
         Get account information

--- a/primehub/schedules.py
+++ b/primehub/schedules.py
@@ -72,10 +72,10 @@ class Schedules(Helpful, Module):
         }
         """
         variables = {
-          'where': {
-            'groupId_in': [self.group_id]
-          },
-          'page': 1
+            'where': {
+                'groupId_in': [self.group_id]
+            },
+            'page': 1
         }
         if kwargs.get('page', None):
             variables['page'] = kwargs['page']
@@ -92,7 +92,7 @@ class Schedules(Helpful, Module):
                 break
         return edges
 
-    @cmd(name='get', description='Get a schedule by id')
+    @cmd(name='get', description='Get a schedule by id', return_required=True)
     def get(self, id):
         """
         Get detail information of a schedule by id

--- a/primehub/utils/__init__.py
+++ b/primehub/utils/__init__.py
@@ -23,6 +23,10 @@ class ResponseException(PrimeHubException):
     pass
 
 
+class PrimeHubReturnsRequiredException(PrimeHubException):
+    pass
+
+
 def reject_action(action):
     raise UserRejectAction(
         'User rejects action [%s], please use the flag "--yes-i-really-mean-it" to allow the action.' % action)

--- a/primehub/utils/decorators.py
+++ b/primehub/utils/decorators.py
@@ -65,6 +65,8 @@ def cmd(**cmd_args):
         raise ValueError('name description is required')
     if 'optionals' not in cmd_args:
         cmd_args['optionals'] = []
+    if 'return_required' not in cmd_args:
+        cmd_args['return_required'] = False
 
     for idx, opts in enumerate(cmd_args['optionals']):
         maybe_builder = opts[-1]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -61,7 +61,7 @@ class BaseTestCase(TestCase):
         self.invoke_cli(argv)
         return self.sdk.stdout.getvalue()
 
-    def invoke_cli(self, argv):
+    def invoke_cli(self, argv: list):
         try:
             import sys
             sys.argv = argv


### PR DESCRIPTION
Add `return_required` flag to @cmd
* it has default value `False` that means no return values are acceptable and cli will exit with the code `0`
  * if there is no `return_required` in the `@cmd`, it uses the default value.
* if it was set `True` that meant return values were required and cli would exit with the code `1`

### Example



```python
@cmd(name='return-required-no-retruns', description='return none for return required', return_required=True)
def return_required_but_no_returns(self):
    # got exit 1
    return None

@cmd(name='return-required-with-retruns', description='return values for return required', return_required=True)
def return_required_with_returns(self):
    # got exit 0
    return "I don't care"
```