### PR TITLE
Human friendly output

### DIFF
--- a/primehub/__init__.py
+++ b/primehub/__init__.py
@@ -311,8 +311,8 @@ class Module(object):
         else:
             return HumanFriendlyDisplay()
 
-    def display(self, action: dict, return_value: Any):
-        self.get_display().display(action, return_value, self.primehub.stdout)
+    def display(self, action: dict, value: Any):
+        self.get_display().display(action, value, self.primehub.stdout)
 
 
 def has_data_from_stdin():

--- a/primehub/__init__.py
+++ b/primehub/__init__.py
@@ -3,10 +3,11 @@ import importlib
 import json
 import os
 import sys
-from typing import Union, Callable, Dict
+from typing import Union, Callable, Dict, Any
 
 from primehub.utils import group_required, create_logger
 from primehub.utils.decorators import cmd  # noqa: F401
+from primehub.utils.display import Display
 from primehub.utils.http_client import Client
 
 logger = create_logger('primehub-config')
@@ -275,6 +276,7 @@ class Module(object):
         self.request = primehub.request
         self.request_logs = primehub.request_logs
         self.request_file = primehub.request_file
+        self.cli_display = Display('json')
 
     @property
     def current_group(self) -> dict:
@@ -302,6 +304,9 @@ class Module(object):
         raise ValueError(
             'The attribute [primehub_config] is access denied, '
             'please use props of the Module to get configurations')
+
+    def display(self, action: dict, return_value: Any):
+        self.cli_display.display(action, return_value, self.primehub.stdout)
 
 
 def has_data_from_stdin():

--- a/primehub/__init__.py
+++ b/primehub/__init__.py
@@ -7,7 +7,7 @@ from typing import Union, Callable, Dict, Any
 
 from primehub.utils import group_required, create_logger
 from primehub.utils.decorators import cmd  # noqa: F401
-from primehub.utils.display import Display
+from primehub.utils.display import Display, HumanFriendlyDisplay, Displayable
 from primehub.utils.http_client import Client
 
 logger = create_logger('primehub-config')
@@ -181,6 +181,7 @@ class PrimeHub(object):
 
     def __init__(self, config: PrimeHubConfig):
         self.primehub_config = config
+        self.json_output = True
         self.commands: Dict[str, Module] = dict()
         self._stderr = sys.stderr
         self._stdout = sys.stdout
@@ -276,7 +277,6 @@ class Module(object):
         self.request = primehub.request
         self.request_logs = primehub.request_logs
         self.request_file = primehub.request_file
-        self.cli_display = Display('json')
 
     @property
     def current_group(self) -> dict:
@@ -305,8 +305,14 @@ class Module(object):
             'The attribute [primehub_config] is access denied, '
             'please use props of the Module to get configurations')
 
+    def get_display(self) -> Displayable:
+        if self.primehub.json_output:
+            return Display()
+        else:
+            return HumanFriendlyDisplay()
+
     def display(self, action: dict, return_value: Any):
-        self.cli_display.display(action, return_value, self.primehub.stdout)
+        self.get_display().display(action, return_value, self.primehub.stdout)
 
 
 def has_data_from_stdin():

--- a/primehub/cli.py
+++ b/primehub/cli.py
@@ -213,6 +213,9 @@ def main(sdk=None):
         logger.debug("remaining_args: {}".format(remaining_args))
         reconfigure_primehub_config_if_needed(args, sdk)
 
+        # configure output format from main-parser
+        sdk.json_output = args.json_output
+
         if command_name not in sdk.commands:
             main_parser.epilog = 'Error: "{}" command not found'.format(command_name)
             sys.exit(1)

--- a/primehub/extras/e2e.py
+++ b/primehub/extras/e2e.py
@@ -32,7 +32,7 @@ class E2EForBasicFunction(Helpful, Module):
         self.endline()
 
         self.title('Groups')
-        group: Groups = self.primehub.group
+        group: Groups = self.primehub.groups
         for g in group.list():
             print(g['id'], g['name'])
         self.endline()
@@ -64,7 +64,7 @@ class E2EForBasicFunction(Helpful, Module):
         with open(path, "w") as fh:
             fh.write(json.dumps(job_spec))
 
-        my_job = self.primehub.jobs.submit(file=path)
+        my_job = self.primehub.jobs.submit_cmd(file=path)
         my_id = my_job['id']
         print("Job ID:", my_job['id'])
 

--- a/primehub/jobs.py
+++ b/primehub/jobs.py
@@ -1,4 +1,4 @@
-from typing import Iterator
+from typing import Iterator, Any
 
 from primehub import Helpful, cmd, Module, has_data_from_stdin
 import time
@@ -430,6 +430,13 @@ class Jobs(Helpful, Module):
             return
         self.request_file(endpoint + path, dest + os.path.basename(path))
         return
+
+    def display(self, action: dict, value: Any):
+        if action['func'] == 'list_artifacts' and isinstance(value, dict) and self.get_display().name != 'json':
+            file_list = value.get('items', [])
+            self.get_display().display(action, file_list, self.primehub.stdout)
+        else:
+            super(Jobs, self).display(action, value)
 
     def help_description(self):
         return "Get a job or list jobs"

--- a/primehub/utils/argparser/__init__.py
+++ b/primehub/utils/argparser/__init__.py
@@ -98,10 +98,12 @@ def add_global_options(p):
     help_opts = p.add_argument_group('Options')
     help_opts.add_argument('-h', '--help', help='Show the help', action='store_true', default=False, dest='show_help')
     opts = p.add_argument_group('Global Options')
-    opts.add_argument('--config', help='the path of the config file')
-    opts.add_argument('--endpoint', help='the endpoint to the PrimeHub GraphQL URL')
-    opts.add_argument('--token', help='API Token generated from PrimeHub Console')
-    opts.add_argument('--group', help='override the active group')
+    opts.add_argument('--config', help='Change the path of the config file (Default: ~/.primehub/config.json)')
+    opts.add_argument('--endpoint', help='Override the GraphQL API endpoint')
+    opts.add_argument('--token', help='Override the API Token')
+    opts.add_argument('--group', help='Override the current group')
+    opts.add_argument('--json', help='Output the json format (output human-friendly format by default.)',
+                      dest='json_output', action='store_true')
 
 
 def create_command_parser(description=None):

--- a/primehub/utils/display.py
+++ b/primehub/utils/display.py
@@ -1,0 +1,54 @@
+import json
+from types import GeneratorType
+from typing import Any, TextIO, Union
+
+from primehub import create_logger
+
+logger = create_logger('display')
+
+
+def wrapper_generator(gen):
+    is_type_sent = False
+    for x in gen:
+        if not is_type_sent:
+            yield isinstance(x, str)
+            is_type_sent = True
+        yield x
+
+
+class Display(object):
+
+    def __init__(self, name: str):
+        self.name = name
+
+    def display(self, action: dict, value: Any, file: TextIO):
+        if not value:
+            return
+
+        if isinstance(value, GeneratorType):
+            logger.debug('display generator-type')
+            wrapped_generator = wrapper_generator(value)
+            is_str = next(wrapped_generator, None)
+            if is_str is None:
+                return
+            if is_str:
+                for x in wrapped_generator:
+                    self.display_single(x, file)
+            else:
+                self.display(action, list(wrapped_generator), file)
+        else:
+            if isinstance(value, dict) or isinstance(value, list):
+                self.display_many(value, file)
+            else:
+                self.display_single(value, file)
+
+    def display_many(self, value: Union[dict, list], file: TextIO):
+        logger.debug('display-many')
+        json.dump(value, file)
+
+    def display_single(self, value: Any, file: TextIO):
+        logger.debug('display-single')
+        if isinstance(value, str):
+            print(value, file=file)
+        else:
+            json.dump(value, file)

--- a/primehub/utils/display.py
+++ b/primehub/utils/display.py
@@ -1,10 +1,83 @@
 import json
+
 from types import GeneratorType
-from typing import Any, TextIO, Union
+from typing import Any, TextIO, Union, Dict, List
+
+from tabulate import tabulate
 
 from primehub import create_logger
+from abc import ABCMeta, abstractmethod
 
 logger = create_logger('display')
+
+CUSTOMIZED_COLUMNS: Dict[str, List[tuple]] = {
+    'primehub.jobs.list': [
+        ('id',),
+        ('displayName',),
+        ('schedule',),
+        ('userName', 'user',),
+        ('startTime',),
+        ('finishTime',),
+        ('phase',),
+    ],
+    'primehub.schedules.list': [
+        ('id',),
+        ('displayName',),
+        ('recurrence',),
+        ('userName', 'createdBy',),
+        ('nextRunTime',),
+    ],
+    'primehub.images.list': [
+        ('name',),
+        ('displayName',),
+        ('description',),
+    ],
+    'primehub.deployments.list': [
+        ('id',),
+        ('name',),
+        ('modelImage',),
+        ('description',),
+        ('stop',),
+        ('status',),
+        ('message',),
+    ]
+}
+
+
+def display_tree_like_format(data, file: TextIO, width=0, indent=0):
+    output = data.items()
+    if width == 0:
+        width = 2 + max([len(x[0]) for x in output])
+        if width < 15:
+            width = 15
+
+    for k, v in output:
+        remaining = width - len(k)
+        if isinstance(v, dict):
+            print("{}{}:".format(" " * indent, k), file=file)
+            display_tree_like_format(v, file, width - 2, indent + 2)
+        else:
+            print("{}{}:{}{}".format(" " * indent, k, " " * remaining, v), file=file)
+
+
+class Displayable(metaclass=ABCMeta):
+
+    @property
+    @abstractmethod
+    def name(self):
+        pass
+
+    @abstractmethod
+    def display(self, action: dict, value: Any, file: TextIO):
+        pass
+
+    @abstractmethod
+    def display_many(self, action: dict, value: Union[dict, list], file: TextIO):
+        pass
+
+    @abstractmethod
+    def display_single(self, action: dict, value: Any, file: TextIO):
+        pass
 
 
 def wrapper_generator(gen):
@@ -16,14 +89,16 @@ def wrapper_generator(gen):
         yield x
 
 
-class Display(object):
+class Display(Displayable):
 
-    def __init__(self, name: str):
-        self.name = name
+    @property
+    def name(self):
+        return 'json'
 
     def display(self, action: dict, value: Any, file: TextIO):
         if not value:
             return
+        logger.debug('use display %s', self.name)
 
         if isinstance(value, GeneratorType):
             logger.debug('display generator-type')
@@ -33,22 +108,79 @@ class Display(object):
                 return
             if is_str:
                 for x in wrapped_generator:
-                    self.display_single(x, file)
+                    self.display_single(action, x, file)
             else:
                 self.display(action, list(wrapped_generator), file)
         else:
             if isinstance(value, dict) or isinstance(value, list):
-                self.display_many(value, file)
+                self.display_many(action, value, file)
             else:
-                self.display_single(value, file)
+                self.display_single(action, value, file)
 
-    def display_many(self, value: Union[dict, list], file: TextIO):
+    def display_many(self, action: dict, value: Union[dict, list], file: TextIO):
         logger.debug('display-many')
         json.dump(value, file)
 
-    def display_single(self, value: Any, file: TextIO):
+    def display_single(self, action: dict, value: Any, file: TextIO):
         logger.debug('display-single')
         if isinstance(value, str):
             print(value, file=file)
         else:
             json.dump(value, file)
+
+
+class HumanFriendlyDisplay(Displayable):
+
+    @property
+    def name(self):
+        return 'human-friendly'
+
+    def display(self, action: dict, value: Any, file: TextIO):
+        if not value:
+            return
+        logger.debug('use display %s', self.name)
+
+        if isinstance(value, GeneratorType):
+            logger.debug('display generator-type')
+            wrapped_generator = wrapper_generator(value)
+            is_str = next(wrapped_generator, None)
+            if is_str is None:
+                return
+            if is_str:
+                for x in wrapped_generator:
+                    self.display_single(action, x, file)
+            else:
+                self.display(action, list(wrapped_generator), file)
+        else:
+            # for human-friendly dict type will use display_single
+            if isinstance(value, list):
+                self.display_many(action, value, file)
+            else:
+                self.display_single(action, value, file)
+
+    def display_many(self, action: dict, value: Union[dict, list], file: TextIO):
+        logger.debug('display-many')
+
+        # 'module': 'primehub.jobs', 'func': 'list'
+        customized_key = "{}.{}".format(action['module'], action['func'])
+        if customized_key not in CUSTOMIZED_COLUMNS:
+            print(tabulate(value, headers="keys"), file=file)
+        else:
+            def transform(columns: list, v: Union[dict, list]):
+                for x in v:
+                    result = {}
+                    for c in columns:
+                        column_name = column_alias = c[0]
+                        if len(c) == 2:
+                            column_alias = c[1]
+                        result[column_alias] = x[column_name]
+                    yield result
+
+            print(tabulate(transform(CUSTOMIZED_COLUMNS[customized_key], value), headers="keys"), file=file)
+
+    def display_single(self, action: dict, value: Any, file: TextIO):
+        logger.debug('display-single')
+        if isinstance(value, str):
+            print(value, file=file)
+        else:
+            display_tree_like_format(value, file)

--- a/primehub/utils/http_client.py
+++ b/primehub/utils/http_client.py
@@ -5,7 +5,9 @@ from typing import Iterator
 
 import requests  # type: ignore
 
-from primehub.utils import ResponseException, RequestException, GraphQLException
+from primehub.utils import ResponseException, RequestException, GraphQLException, create_logger
+
+logger = create_logger('http')
 
 
 class Client(object):
@@ -16,10 +18,12 @@ class Client(object):
 
     def request(self, variables: dict, query: str):
         request_body = dict(variables=json.dumps(variables), query=query)
+        logger.debug('request body: {}'.format(request_body))
         headers = {'authorization': 'Bearer {}'.format(self.primehub_config.api_token)}
         try:
             content = requests.post(self.primehub_config.endpoint, data=request_body, headers=headers,
                                     timeout=self.timeout).text
+            logger.debug('response: {}'.format(content))
             result = json.loads(content)
             if 'errors' in result:
                 raise GraphQLException(result)

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(name='primehub-python-sdk',
       },
       python_requires=">=3.6",
       packages=find_packages(),
-      install_requires=['requests'],
+      install_requires=['requests', 'tabulate==0.8.9', 'types-tabulate==0.8.2'],
       extras_require={
           'dev': [
               'pytest>=4.6',

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -67,6 +67,8 @@ class BaseTestCase(TestCase):
             sys.argv = argv
             if [x for x in argv if not isinstance(x, str)]:
                 raise ValueError('all arguments must be a str type')
+            if '--json' not in sys.argv:
+                sys.argv.append('--json')
             cli.main(sdk=self.sdk)
         except SystemExit:
             pass


### PR DESCRIPTION
## Add json output flag

By default, we will output in the *human-friendly* format

```
Usage:
  primehub <command>

[..skip..]

Global Options:
  --config CONFIG      Change the path of the config file (Default: ~/.primehub/config.json)
  --endpoint ENDPOINT  Override the GraphQL API endpoint
  --token TOKEN        Override the API Token
  --group GROUP        Override the current group
  --json               Output the json format (output human-friendly format by default.)
```

## Output examples

### jobs

```
$ primehub jobs list | head
id                       displayName         schedule         user     startTime             finishTime            phase
-----------------------  ------------------  ---------------  -------  --------------------  --------------------  ---------
job-202108110819-6nhw75  job-e2e                              phadmin  2021-08-11T08:19:45Z  2021-08-11T08:20:08Z  Succeeded
job-202108110749-lnugr0  job-e2e                              phadmin  2021-08-11T07:49:39Z  2021-08-11T07:50:01Z  Succeeded
job-202108110400-1e8yhn  Do my best job      schedule-moqib3  phadmin  2021-08-11T04:00:10Z  2021-08-11T04:00:11Z  Succeeded
job-202108100400-bkg9p6  Do my best job      schedule-moqib3  phadmin  2021-08-10T04:00:10Z  2021-08-10T04:00:11Z  Succeeded
job-202108090400-2afhk8  Do my best job      schedule-moqib3  phadmin  2021-08-09T04:00:04Z  2021-08-09T04:00:05Z  Succeeded
job-202108080400-q1ym7k  Do my best job      schedule-moqib3  phadmin  2021-08-08T04:00:04Z  2021-08-08T04:00:05Z  Succeeded
job-202108070400-hubqpp  Do my best job      schedule-moqib3  phadmin  2021-08-07T04:00:07Z  2021-08-07T04:00:08Z  Succeeded
job-202108060400-v790ry  Do my best job      schedule-moqib3  phadmin  2021-08-06T04:00:11Z  2021-08-06T04:00:12Z  Succeeded
```

```
id:             job-202108110819-6nhw75
displayName:    job-e2e
cancel:         None
command:
        sudo apt-get update -y
        sudo apt-get install -y git
        pip install git+https://github.com/InfuseAI/primehub-python-sdk.git@main
        primehub -h
        echo
        exit 0

groupId:        2b080113-e2f1-4b1b-a6ef-eb0ca5e2f376
groupName:      phusers
schedule:       None
image:          base-notebook
instanceType:
  id:           cpu-1
  name:         cpu-1
  displayName:  CPU 1
  cpuLimit:     0.5
  memoryLimit:  2
  gpuLimit:     0
userId:         a7db12dc-04fa-419c-9cd7-af768575a871
userName:       phadmin
phase:          Succeeded
reason:         PodSucceeded
message:        Job completed
createTime:     2021-08-11T08:19:34Z
startTime:      2021-08-11T08:19:45Z
finishTime:     2021-08-11T08:20:08Z
```

### deployments

```
$ primehub deployments list
id                     name             modelImage                           description    stop    status    message
---------------------  ---------------  -----------------------------------  -------------  ------  --------  ----------------------------------------
quickstart-iris-52wn6  quickstart-iris  infuseai/sklearn-prepackaged:v0.1.0                 False   Deployed  Deployment is deployed and available now
```

```
$ primehub deployments get quickstart-iris-52wn6
id:                  quickstart-iris-52wn6
name:                quickstart-iris
modelImage:          infuseai/sklearn-prepackaged:v0.1.0
imagePullSecret:     None
description:         None
replicas:            1
stop:                False
endpointAccessType:  public
endpointClients:     []
status:              Deployed
endpoint:            https://qty0712-microk8s.aws.primehub.io/deployment/quickstart-iris-52wn6/api/v1.0/predictions
availableReplicas:   1
message:             Deployment is deployed and available now
pods:                [{'name': 'deploy-quickstart-iris-52wn6-b69d4bcb4-84nt5'}]
```

## Cusomtize for table view

please update `display.py`

* key is the command full qualified name 
* values are tuples should be display
  * first value: select the column
  * second value: alias for column

```py
CUSTOMIZED_COLUMNS: Dict[str, List[tuple]] = {
    'primehub.jobs.list': [
        ('id',),
        ('displayName',),
        ('schedule',),
        ('userName', 'user',),
        ('startTime',),
        ('finishTime',),
        ('phase',),
    ],
    'primehub.schedules.list': [
        ('id',),
        ('displayName',),
        ('recurrence',),
        ('userName', 'createdBy',),
        ('nextRunTime',),
    ],
    'primehub.images.list': [
        ('name',),
        ('displayName',),
        ('description',),
    ],
    'primehub.deployments.list': [
        ('id',),
        ('name',),
        ('modelImage',),
        ('description',),
        ('stop',),
        ('status',),
        ('message',),
    ]
}

```

### customization for a specific command

see the `jobs.py`

```py
    def display(self, action: dict, value: Any):
        if action['func'] == 'list_artifacts' and isinstance(value, dict) and self.get_display().name != 'json':
            file_list = value.get('items', [])
            self.get_display().display(action, file_list, self.primehub.stdout)
        else:
            super(Jobs, self).display(action, value)

```