### PR TITLE
Add release github action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a variety of Python versions
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: Python package
+name: CI tests
 
 on:
   push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,47 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Release to PyPI
+
+on:
+  push:
+    tags: 'v*'
+
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [ 3.6 ]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: Run tests
+        run: |
+          make test
+      - name: Release
+        run: |
+          # get version from GITHUB_REF
+          # input: "refs/tags/v0.1.0"
+          # outpu: "0.1.0"
+
+          # update version number
+          echo "${GITHUB_REF:11}" > ./primehub/VERSION
+
+          # generate pypirc
+          echo "$PYPIRC" > $HOME/.pypirc
+
+          # release to PyPI
+          make release
+        env:
+          PYPIRC: ${{ secrets.PYPI }}

--- a/Makefile
+++ b/Makefile
@@ -17,5 +17,11 @@ docs: dev-requires
 	doc-primehub
 
 pre-release: dev-requires
+	pip install build
 	python3 -m build
 	python3 -m twine upload --repository testpypi dist/*
+
+release: dev-requires
+	pip install build
+	python3 -m build
+	python3 -m twine upload dist/*


### PR DESCRIPTION
* release to PyPI when a `v*` tag created


## Details

1. create a PyPI API Token for GitHub Action
2. put the Token to the Secrets (in the Settings)
3. create `.pypirc` before publish to PYPI