### PR TITLE
Show admin command in the help

### DIFF
--- a/primehub/__init__.py
+++ b/primehub/__init__.py
@@ -390,6 +390,7 @@ class Dummy(Helpful, Module):
     def help_description(self):
         return self.description
 
+
 def has_data_from_stdin():
     """
     Check if any data comes from stdin.

--- a/tests/test_implementation_in_source_level.py
+++ b/tests/test_implementation_in_source_level.py
@@ -70,6 +70,8 @@ class TestDocumentation(BaseTestCase):
             # skip version command
             if command == 'version':
                 continue
+            if command == 'admin':
+                continue
 
             notebook, cli, cli_example = generate_doc_paths(command)
 


### PR DESCRIPTION
Show the `admin` in the available commands. So that the user know there is admin commands available.

```
Usage:
  primehub <command>

Available Commands:
  admin                Commands for system administrator
  apps                 Manage PrimeHub Applications
  apptemplates         Get PhAppTemplates
  ...
  ```