### PR TITLE
Show graphql formatting problems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -247,4 +247,5 @@ pyvenv.cfg
 pip-selfcheck.json
 
 .DS_Store
+._gql_check_*
 # End of https://www.toptal.com/developers/gitignore/api/python,pycharm+all,venv

--- a/Makefile
+++ b/Makefile
@@ -5,13 +5,16 @@ dev-requires:
 	pip install -e .[dev]
 
 test: dev-requires
-	py.test --cov=primehub --cov-report xml --flake8 --mypy
+	py.test --cov=primehub --cov-report xml --flake8 --mypy --ignore=tests/test_graphql_lint.py
 
 test-html: dev-requires
-	py.test --cov=primehub --cov-report html --flake8 --mypy
+	py.test --cov=primehub --cov-report html --flake8 --mypy --ignore=tests/test_graphql_lint.py
 
 test-regression:
 	PRIMEHUB_SDK_DEVLAB=true primehub e2e basic-functions
+
+test-gql: dev-requires
+	py.test tests/test_graphql_lint.py
 
 docs: dev-requires
 	doc-primehub

--- a/primehub/admin_datasets.py
+++ b/primehub/admin_datasets.py
@@ -90,7 +90,10 @@ class AdminDatasets(Helpful, Module):
         """
 
         query = """
-        mutation UpdateDatasetMutation($payload: DatasetUpdateInput!, $where: DatasetWhereUniqueInput!) {
+        mutation UpdateDatasetMutation(
+          $payload: DatasetUpdateInput!
+          $where: DatasetWhereUniqueInput!
+        ) {
           updateDataset(data: $payload, where: $where) {
             id
           }
@@ -102,7 +105,10 @@ class AdminDatasets(Helpful, Module):
 
         if config.get('enableUploadServer', False):
             query = """
-            mutation UpdateDatasetMutation($payload: DatasetUpdateInput!, $where: DatasetWhereUniqueInput!) {
+            mutation UpdateDatasetMutation(
+              $payload: DatasetUpdateInput!
+              $where: DatasetWhereUniqueInput!
+            ) {
               updateDataset(data: $payload, where: $where) {
                 id
                 uploadServerSecret {
@@ -134,7 +140,9 @@ class AdminDatasets(Helpful, Module):
         """
 
         query = """
-        mutation RegenerateUploadServerSecretMutation($where: DatasetWhereUniqueInput!) {
+        mutation RegenerateUploadServerSecretMutation(
+          $where: DatasetWhereUniqueInput!
+        ) {
           regenerateUploadServerSecret(where: $where) {
             id
             uploadServerSecret {
@@ -153,7 +161,11 @@ class AdminDatasets(Helpful, Module):
     @cmd(name='list', description='List a dataset by id', return_required=True, optionals=[('page', int)])
     def list(self, **kwargs):
         query = """
-        query GetDatasets($page: Int, $orderBy: DatasetOrderByInput, $where: DatasetWhereInput) {
+        query GetDatasets(
+          $page: Int
+          $orderBy: DatasetOrderByInput
+          $where: DatasetWhereInput
+        ) {
           datasetsConnection(page: $page, orderBy: $orderBy, where: $where) {
             edges {
               cursor

--- a/primehub/admin_instancetypes.py
+++ b/primehub/admin_instancetypes.py
@@ -96,7 +96,10 @@ class AdminInstanceTypes(Helpful, Module):
         self._valid_update(config, id)
 
         query = """
-        mutation UpdateInstanceTypeMutation($payload: InstanceTypeUpdateInput!, $where: InstanceTypeWhereUniqueInput!) {
+        mutation UpdateInstanceTypeMutation(
+          $payload: InstanceTypeUpdateInput!
+          $where: InstanceTypeWhereUniqueInput!
+        ) {
           updateInstanceType(data: $payload, where: $where) {
             id
             global
@@ -234,7 +237,11 @@ class AdminInstanceTypes(Helpful, Module):
         :return instance type iterator
         """
         query = """
-        query InstanceTypesQuery($page: Int, $where: InstanceTypeWhereInput, $orderBy: InstanceTypeOrderByInput) {
+        query InstanceTypesQuery(
+          $page: Int
+          $where: InstanceTypeWhereInput
+          $orderBy: InstanceTypeOrderByInput
+        ) {
           instanceTypesConnection(page: $page, where: $where, orderBy: $orderBy) {
             edges {
               cursor
@@ -249,7 +256,6 @@ class AdminInstanceTypes(Helpful, Module):
             }
           }
         }
-
         fragment InstanceTypeInfo on InstanceType {
           id
           name

--- a/primehub/admin_users.py
+++ b/primehub/admin_users.py
@@ -79,8 +79,14 @@ class AdminUsers(Helpful, Module):
         :return user iterator
         """
         query = """
-        query UsersConnection($userAfter: String, $userBefore: String, $userLast: Int, $userFirst: Int,
-            $where: UserWhereInput, $userOrderBy: UsersOrderBy) {
+        query UsersConnection(
+          $userAfter: String
+          $userBefore: String
+          $userLast: Int
+          $userFirst: Int
+          $where: UserWhereInput
+          $userOrderBy: UsersOrderBy
+        ) {
           users: usersConnection(
             after: $userAfter
             before: $userBefore

--- a/primehub/apps.py
+++ b/primehub/apps.py
@@ -294,52 +294,51 @@ class Apps(Helpful, Module):
 
         query = """
         mutation StartPhApplication($where: PhApplicationWhereUniqueInput!) {
-            startPhApplication(where: $where) {
-              ...PhApplicationInfo
-            }
+          startPhApplication(where: $where) {
+            ...PhApplicationInfo
           }
-
-          fragment PhApplicationInfo on PhApplication {
-            id
+        }
+        fragment PhApplicationInfo on PhApplication {
+          id
+          displayName
+          appVersion
+          appName
+          appIcon
+          appDefaultEnv {
+            name
+            defaultValue
+            optional
+            description
+          }
+          appTemplate {
+            name
+            docLink
+            description
+          }
+          groupName
+          instanceType
+          instanceTypeSpec {
+            name
             displayName
-            appVersion
-            appName
-            appIcon
-            appDefaultEnv {
-              name
-              defaultValue
-              optional
-              description
-            }
-            appTemplate {
-              name
-              docLink
-              description
-            }
-            groupName
-            instanceType
-            instanceTypeSpec {
-              name
-              displayName
-              cpuLimit
-              memoryLimit
-              gpuLimit
-            }
-            scope
-            appUrl
-            internalAppUrl
-            svcEndpoints
-            env {
-              name
-              value
-            }
-            stop
-            status
-            message
-            pods {
-              logEndpoint
-            }
+            cpuLimit
+            memoryLimit
+            gpuLimit
           }
+          scope
+          appUrl
+          internalAppUrl
+          svcEndpoints
+          env {
+            name
+            value
+          }
+          stop
+          status
+          message
+          pods {
+            logEndpoint
+          }
+        }
         """
         results = self.request({'where': {'id': id}}, query)
         if 'data' in results and 'startPhApplication' in results['data']:

--- a/primehub/deployments.py
+++ b/primehub/deployments.py
@@ -78,7 +78,7 @@ class Deployments(Helpful, Module):
         :return The list of deployments
         """
         query = """
-        query($where: PhDeploymentWhereInput) {
+        query ($where: PhDeploymentWhereInput) {
           phDeployments(where: $where) {
             id
             name
@@ -118,7 +118,7 @@ class Deployments(Helpful, Module):
         """
         query = """
         query ($where: PhDeploymentWhereUniqueInput!) {
-          phDeployment (where: $where) {
+          phDeployment(where: $where) {
             id
             name
             modelImage
@@ -157,7 +157,7 @@ class Deployments(Helpful, Module):
         """
         query = """
         query ($where: PhDeploymentWhereUniqueInput!) {
-          phDeployment (where: $where) {
+          phDeployment(where: $where) {
             history {
               time
               deployment {
@@ -271,7 +271,10 @@ class Deployments(Helpful, Module):
         :return The detail information of the updated deployment
         """
         query = """
-        mutation ($data: PhDeploymentUpdateInput!, $where: PhDeploymentWhereUniqueInput!) {
+        mutation (
+          $data: PhDeploymentUpdateInput!
+          $where: PhDeploymentWhereUniqueInput!
+        ) {
           updatePhDeployment(data: $data, where: $where) {
             id
             name
@@ -313,8 +316,8 @@ class Deployments(Helpful, Module):
         :return The detail information of the started deployment
         """
         query = """
-        mutation ($where:PhDeploymentWhereUniqueInput!) {
-          deployPhDeployment (where: $where) {
+        mutation ($where: PhDeploymentWhereUniqueInput!) {
+          deployPhDeployment(where: $where) {
             id
             name
             modelImage
@@ -352,8 +355,8 @@ class Deployments(Helpful, Module):
         :return The detail information of the stopped deployment
         """
         query = """
-        mutation ($where:PhDeploymentWhereUniqueInput!) {
-          stopPhDeployment (where: $where) {
+        mutation ($where: PhDeploymentWhereUniqueInput!) {
+          stopPhDeployment(where: $where) {
             id
             name
             modelImage
@@ -422,7 +425,7 @@ class Deployments(Helpful, Module):
         """
         query = """
         query ($where: PhDeploymentWhereUniqueInput!) {
-          phDeployment (where: $where) {
+          phDeployment(where: $where) {
             pods {
               name
               phase
@@ -457,7 +460,7 @@ class Deployments(Helpful, Module):
         """
         query = """
         query ($where: PhDeploymentWhereUniqueInput!) {
-          phDeployment (where: $where) {
+          phDeployment(where: $where) {
             stop
             status
           }

--- a/primehub/files.py
+++ b/primehub/files.py
@@ -121,8 +121,8 @@ class Files(Helpful, Module):
         :return The detail information of files in the path
         """
         query = """
-        query files($where: StoreFileWhereInput!, , $options: StoreFileListOptionInput) {
-          files (where: $where, options: $options) {
+        query files($where: StoreFileWhereInput!, $options: StoreFileListOptionInput) {
+          files(where: $where, options: $options) {
             phfsPrefix
             items {
               name

--- a/primehub/models.py
+++ b/primehub/models.py
@@ -24,10 +24,10 @@ class Models(Helpful, Module):
 
         query = """
         query QueryModels($group: String!) {
-          mlflow(where: {group: $group}) {
+          mlflow(where: { group: $group }) {
             ...MLflowSettingInfo
           }
-          models(where: {group: $group}) {
+          models(where: { group: $group }) {
             ...ModelInfo
           }
         }
@@ -72,22 +72,20 @@ class Models(Helpful, Module):
 
         query = """
         query QueryModel($group: String!, $name: String!) {
-          mlflow(where: {group: $group}) {
+          mlflow(where: { group: $group }) {
             ...MLflowSettingInfo
           }
-          model(where: {group: $group, name: $name}) {
+          model(where: { group: $group, name: $name }) {
             ...ModelInfo
           }
-          modelVersions(where: {group: $group, name: $name}) {
+          modelVersions(where: { group: $group, name: $name }) {
             ...ModelVersionInfo
           }
         }
-
         fragment MLflowSettingInfo on MLflowSetting {
           trackingUri
           uiUrl
         }
-
         fragment ModelInfo on Model {
           name
           creationTimestamp
@@ -98,7 +96,6 @@ class Models(Helpful, Module):
             version
           }
         }
-
         fragment ModelVersionInfo on ModelVersion {
           name
           version
@@ -128,11 +125,10 @@ class Models(Helpful, Module):
 
         query = """
         query QueryModel($group: String!, $name: String!) {
-          modelVersions(where: {group: $group, name: $name}) {
+          modelVersions(where: { group: $group, name: $name }) {
             ...ModelVersionInfo
           }
         }
-
         fragment ModelVersionInfo on ModelVersion {
           name
           version
@@ -169,20 +165,18 @@ class Models(Helpful, Module):
 
         query = """
         query QueryModelVersion($group: String!, $name: String!, $version: String!) {
-          mlflow(where: {group: $group}) {
+          mlflow(where: { group: $group }) {
             ...MLflowSettingInfo
           }
-          modelVersion(where: {group: $group, name: $name, version: $version}) {
+          modelVersion(where: { group: $group, name: $name, version: $version }) {
             ...ModelVersionInfo
             run
           }
         }
-
         fragment MLflowSettingInfo on MLflowSetting {
           trackingUri
           uiUrl
         }
-
         fragment ModelVersionInfo on ModelVersion {
           name
           version

--- a/primehub/schedules.py
+++ b/primehub/schedules.py
@@ -73,7 +73,11 @@ class Schedules(Helpful, Module):
         :return The list of schedules
         """
         query = """
-        query ($where: PhScheduleWhereInput, $page: Int, $orderBy: PhScheduleOrderByInput) {
+        query (
+          $where: PhScheduleWhereInput
+          $page: Int
+          $orderBy: PhScheduleOrderByInput
+        ) {
           phSchedulesConnection(where: $where, page: $page, orderBy: $orderBy) {
             pageInfo {
               totalPage

--- a/tests/graphql_formatter.py
+++ b/tests/graphql_formatter.py
@@ -1,0 +1,20 @@
+import subprocess
+import tempfile
+
+
+def is_formatter_available():
+    try:
+        process = subprocess.run(['prettier', '-h'], capture_output=True)
+        return process.stdout.decode('utf8').startswith('Usage: prettier')
+    except BaseException:
+        return False
+
+
+def format_graphql(graphql_query):
+    _, gql = tempfile.mkstemp(suffix=".graphql")
+    with open(gql, 'w') as f:
+        f.write(graphql_query)
+    process = subprocess.run(['prettier', gql], capture_output=True)
+    if process.returncode != 0:
+        raise BaseException(f'Can not format the query:\n\n{graphql_query}\n')
+    return process.stdout.decode('utf8')

--- a/tests/test_graphql_lint.py
+++ b/tests/test_graphql_lint.py
@@ -1,0 +1,97 @@
+import ast
+import os
+import re
+import textwrap
+from unittest import TestCase
+
+from tests.graphql_formatter import is_formatter_available, format_graphql
+
+
+class GraphQLQueryFormatChecker(ast.NodeTransformer):
+
+    def __init__(self, testutil: TestCase, filename: str):
+        self.testutil = testutil
+        self.filename = filename
+
+    def visit_Assign(self, node):
+
+        try:
+            n = node.targets[0]
+            if not hasattr(n, 'id'):
+                return node
+
+            if n.id == 'query':
+                first_line_indent = 0
+                for line in node.value.s.split('\n'):
+                    if line.strip() == '':
+                        continue
+                    m = re.search(r'^(\s+).*', line)
+                    if m:
+                        first_line_indent = len(m.group(1))
+                        break
+                gql = strip_blank_line(node.value.s)
+                if has_checkpoint(f'{self.filename}:{n.lineno}', gql):
+                    # skip by checkpoint
+                    return node
+
+                formatted = textwrap.indent(format_graphql(gql), ' ' * first_line_indent)
+                formatted = strip_blank_line(formatted)
+                if gql != formatted:
+                    print(f'check {self.filename}:{n.lineno}')
+                    print(f'please replace the content by this:\n\n>>>>\n{formatted}\n<<<<\n')
+                else:
+                    save_checkpoint(f'{self.filename}:{n.lineno}', gql)
+                self.testutil.assertEqual(gql, formatted)
+        except BaseException as e:
+            if isinstance(e, AssertionError):
+                raise e
+            print(type(e), e)
+
+        return node
+
+
+def strip_blank_line(formatted):
+    return '\n'.join([x for x in formatted.split('\n') if x.strip() != ''])
+
+
+def save_checkpoint(file_loc, content):
+    filepath = os.path.join('/tmp', f'._gql_check_{checksum(file_loc)}.{checksum(content)}')
+    with open(filepath, 'w') as fh:
+        fh.write('')
+
+
+def has_checkpoint(file_loc, content):
+    filepath = os.path.join('/tmp', f'._gql_check_{checksum(file_loc)}.{checksum(content)}')
+    return os.path.exists(filepath)
+
+
+def checksum(content: str):
+    import hashlib
+    m = hashlib.md5(content.encode())
+    return m.hexdigest()
+
+
+def source_contents():
+    project_dir = os.path.normpath(os.path.join(os.path.dirname(__file__), '../primehub'))
+    for root, dirs, files in os.walk(project_dir):
+        for f in files:
+            if f.endswith('.py'):
+                p = os.path.join(root, f)
+                with open(p, 'r') as fh:
+                    content = fh.read()
+                    yield p, content
+        break
+
+
+class GraphQLLint(TestCase):
+
+    def test_graphql_lint(self):
+        if not is_formatter_available():
+            print("GRAPHQL FORMATTER NOT AVAILABLE. (please install prettier first)")
+            print("SKIP GRAPHQL LINT")
+            return
+
+        print("\n---- start to lint graphql ----")
+        for filename, c in source_contents():
+            node = ast.parse(c)
+            GraphQLQueryFormatChecker(self, filename).visit(node)

--- a/tests/test_implementation_in_source_level.py
+++ b/tests/test_implementation_in_source_level.py
@@ -54,7 +54,7 @@ class TestDocumentation(BaseTestCase):
     ./primehub/extras/templates/examples/{command}.ipynb
     """
 
-    def test_verify_ask_for_permissions(self):
+    def test_docs(self):
         project_dir = os.path.normpath(os.path.join(os.path.dirname(__file__), '..'))
 
         def generate_doc_paths(command):


### PR DESCRIPTION
Required:

* prettier (`npm install -g prettier`)
* the graphql query must be a simple assignment expression with a `query` id

Usage:

```
make test-gql
```

## Output in the console

```
================================================================================================ FAILURES =================================================================================================
______________________________________________________________________________________ GraphQLLint.test_graphql_lint ______________________________________________________________________________________

self = <tests.test_graphql_lint.GraphQLLint testMethod=test_graphql_lint>

    def test_graphql_lint(self):
        if not is_formatter_available():
            print("GRAPHQL FORMATTER NOT AVAILABLE. (please install prettier first)")
            print("SKIP GRAPHQL LINT")
            return

        print("\n---- start to lint graphql ----")
        for filename, c in source_contents():
            node = ast.parse(c)
>           GraphQLQueryFormatChecker(self, filename).visit(node)

tests/test_graphql_lint.py:97:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
/opt/anaconda3/lib/python3.7/ast.py:271: in visit
    return visitor(node)
/opt/anaconda3/lib/python3.7/ast.py:326: in generic_visit
    value = self.visit(value)
/opt/anaconda3/lib/python3.7/ast.py:271: in visit
    return visitor(node)
/opt/anaconda3/lib/python3.7/ast.py:326: in generic_visit
    value = self.visit(value)
/opt/anaconda3/lib/python3.7/ast.py:271: in visit
    return visitor(node)
/opt/anaconda3/lib/python3.7/ast.py:326: in generic_visit
    value = self.visit(value)
/opt/anaconda3/lib/python3.7/ast.py:271: in visit
    return visitor(node)
tests/test_graphql_lint.py:47: in visit_Assign
    raise e
tests/test_graphql_lint.py:44: in visit_Assign
    self.testutil.assertEqual(gql, formatted)
E   AssertionError: '    [79 chars] {\n mlflow(where: { group: $group }) {\n     [473 chars]   }' != '    [79 chars] {\n          mlflow(where: { group: $group })[491 chars]   }'
E   Diff is 784 characters long. Set self.maxDiff to None to see it.
------------------------------------------------------------------------------------------ Captured stdout call -------------------------------------------------------------------------------------------

---- start to lint graphql ----
check /Users/qrtt1/temp/primehub-python-sdk/primehub/models.py:166
please replace the content by this:

>>>>
        query QueryModelVersion($group: String!, $name: String!, $version: String!) {
          mlflow(where: { group: $group }) {
            ...MLflowSettingInfo
          }
          modelVersion(where: { group: $group, name: $name, version: $version }) {
            ...ModelVersionInfo
            run
          }
        }
        fragment MLflowSettingInfo on MLflowSetting {
          trackingUri
          uiUrl
        }
        fragment ModelVersionInfo on ModelVersion {
          name
          version
          creationTimestamp
          lastUpdatedTimestamp
          deployedBy
        }
<<<<

========================================================================================= short test summary info =========================================================================================
FAILED tests/test_graphql_lint.py::GraphQLLint::test_graphql_lint - AssertionError: '    [79 chars] {\n mlflow(where: { group: $group }) {\n     [473 chars]   }' != '    [79 chars] {\n          mlflow...
============================================================================================ 1 failed in 1.70s ============================================================================================
make: *** [test-gql] Error 1
```

### Output in the IDE
![image](https://user-images.githubusercontent.com/193223/139358442-1bd849fd-91e6-4768-a0ef-339add4f49dd.png)
