### PR TITLE
Feature/sc 21470/add admin images support in primehub sdk

### DIFF
--- a/docs/CLI/admin/images.md
+++ b/docs/CLI/admin/images.md
@@ -114,10 +114,106 @@ primehub admin images update <id>
 | name | required | string | it should be a valid resource name for kubernetes. `name` will be ignored when updating |
 | displayName | optional | string | |
 | description | optional | string | |
-| type | required | string | onf of ['cpu', 'gpu', 'both'] |
+| type | required | string | one of ['cpu', 'gpu', 'both'] |
 | global | optional | boolean |  |
 | groups | optional | object | |
 | url | optional | string | container image url |
 | urlForGpu | optional | string | container image url for GPU optimized |
-| imageSpec | optional | object | |
+| imageSpec | optional | object | the specification for customization |
 
+#### imageSpec Example
+
+> YOU MUST ENABLE AND CONFIGURE [CUSTOM IMAGE BUILD](https://docs.primehub.io/docs/getting_started/configure-image-builder)
+
+To use the imageSpec, you need an object like this structure:
+
+```json
+{
+  "baseImage": "jupyter/base-notebook",
+  "packages": {
+    "pip": [
+      "pytest"
+    ]
+  }
+}
+```
+
+* baseImage: a container url for the customization
+* packages: configure package managers and installation list
+    * pip
+    * apt
+    * conda
+
+`packages` is a dictionary and its keys should be one of `['apt', 'conda', 'pip']` and value should be a list for
+packages you want to install
+
+### Manage images by SDK
+
+First, you can find the example by `create` action:
+
+```
+$ primehub admin images create
+
+The configuration is required.
+
+Example:
+{
+  "name": "base",
+  "displayName": "Base image",
+  "description": "base-notebook with python 3.7",
+  "type": "both",
+  "url": "infuseai/docker-stacks:base-notebook-63fdf50a",
+  "urlForGpu": "infuseai/docker-stacks:base-notebook-63fdf50a-gpu",
+  "global": true
+}
+```
+
+Let's use it to create a new image:
+
+```
+$ primehub admin images create <<EOF
+{
+  "name": "my-first-image",
+  "displayName": "Learning how to create an image from SDK",
+  "description": "base-notebook with python 3.7",
+  "type": "both",
+  "url": "infuseai/docker-stacks:base-notebook-63fdf50a",
+  "urlForGpu": "infuseai/docker-stacks:base-notebook-63fdf50a-gpu",
+  "global": true
+}
+EOF
+```
+
+And check the result by `list` action
+
+```
+$ primehub admin images list
+
+id              name            displayName                               description                     type    isReady
+--------------  --------------  ----------------------------------------  ------------------------------  ------  ---------
+base-notebook   base-notebook   base-notebook                             base notebook                   both    True
+pytorch-1       pytorch-1       PyTorch 1.8.0 (Python 3.7)                PyTorch 1.8.0 (Python 3.7)      both    True
+tf-1            tf-1            TensorFlow 1.15.4 (Python 3.7)            TensorFlow 1.15.4 (Python 3.7)  both    True
+tf-2            tf-2            TensorFlow 2.5.0 (Python 3.7)             TensorFlow 2.5.0 (Python 3.7)   both    True
+my-first-image  my-first-image  Learning how to create an image from SDK  base-notebook with python 3.7   both    True
+```
+
+### Build a custom build
+
+```
+$ primehub admin images create <<EOF
+{
+  "name": "my-custom-image",
+  "type": "both",
+  "global": true,
+  "imageSpec": {
+    "baseImage": "jupyter/base-notebook",
+    "packages": {
+      "pip": [
+        "pytest"
+      ]
+    }
+  }
+}
+EOF
+```

--- a/docs/CLI/admin/images.md
+++ b/docs/CLI/admin/images.md
@@ -107,4 +107,17 @@ primehub admin images update <id>
 
 ## Examples
 
-TBD: please write example for [images]
+### Fields for creating or updating
+
+| field | required | type | description |
+| --- | --- | --- | --- |
+| name | required | string | it should be a valid resource name for kubernetes. `name` will be ignored when updating |
+| displayName | optional | string | |
+| description | optional | string | |
+| type | required | string | onf of ['cpu', 'gpu', 'both'] |
+| global | optional | boolean |  |
+| groups | optional | object | |
+| url | optional | string | container image url |
+| urlForGpu | optional | string | container image url for GPU optimized |
+| imageSpec | optional | object | |
+

--- a/docs/CLI/admin/images.md
+++ b/docs/CLI/admin/images.md
@@ -1,0 +1,110 @@
+
+# <ADMIN> Primehub Images
+
+```
+Usage: 
+  primehub admin images <command>
+
+Manage images
+
+Available Commands:
+  create               Create an image
+  delete               Delete an image by id
+  get                  Get an image by id
+  list                 List images
+  update               Update the image
+
+Options:
+  -h, --help           Show the help
+
+Global Options:
+  --config CONFIG      Change the path of the config file (Default: ~/.primehub/config.json)
+  --endpoint ENDPOINT  Override the GraphQL API endpoint
+  --token TOKEN        Override the API Token
+  --group GROUP        Override the current group
+  --json               Output the json format (output human-friendly format by default)
+
+```
+
+
+### create
+
+Create an image
+
+
+```
+primehub admin images create
+```
+ 
+
+* *(optional)* file: The file path of the configurations
+
+
+
+
+### delete
+
+Delete an image by id
+
+
+```
+primehub admin images delete <id>
+```
+
+* id: the id of an image
+ 
+
+
+
+
+### get
+
+Get an image by id
+
+
+```
+primehub admin images get <id>
+```
+
+* id: the id of an image
+ 
+
+
+
+
+### list
+
+List images
+
+
+```
+primehub admin images list
+```
+ 
+
+* *(optional)* page: the page of all data
+
+
+
+
+### update
+
+Update the image
+
+
+```
+primehub admin images update <id>
+```
+
+* id: the id of the image
+ 
+
+* *(optional)* file
+
+
+
+ 
+
+## Examples
+
+TBD: please write example for [images]

--- a/docs/notebook/admin/images.ipynb
+++ b/docs/notebook/admin/images.ipynb
@@ -1,0 +1,480 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "52772ffa",
+   "metadata": {},
+   "source": [
+    "# [admin] Images command\n",
+    "\n",
+    "\n",
+    "The `images` command in `admin` scope could help you manage images.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5ebd5158",
+   "metadata": {},
+   "source": [
+    "## Setup PrimeHub Python SDK\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "1b84ef0f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "PrimeHub Python SDK setup successfully\n"
+     ]
+    }
+   ],
+   "source": [
+    "from primehub import PrimeHub, PrimeHubConfig\n",
+    "ph = PrimeHub(PrimeHubConfig())\n",
+    "\n",
+    "if ph.is_ready():\n",
+    "    print(\"PrimeHub Python SDK setup successfully\")\n",
+    "else:\n",
+    "    print(\"PrimeHub Python SDK couldn't get the group information, follow the 00-getting-started.ipynb to complete it\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5ae057ba",
+   "metadata": {},
+   "source": [
+    "## Help documentation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "fa55f480",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Help on AdminImages in module primehub.admin_images object:\n",
+      "\n",
+      "class AdminImages(primehub.Helpful, primehub.Module)\n",
+      " |  AdminImages(primehub: primehub.PrimeHub, **kwargs)\n",
+      " |  \n",
+      " |  Method resolution order:\n",
+      " |      AdminImages\n",
+      " |      primehub.Helpful\n",
+      " |      primehub.Module\n",
+      " |      builtins.object\n",
+      " |  \n",
+      " |  Methods defined here:\n",
+      " |  \n",
+      " |  create(self, config)\n",
+      " |      Create an image\n",
+      " |      \n",
+      " |      :type config: dict\n",
+      " |      :param config: The configurations for creating an image\n",
+      " |      \n",
+      " |      :rtype dict\n",
+      " |      :return The image\n",
+      " |  \n",
+      " |  delete(self, id)\n",
+      " |      Delete an image by id\n",
+      " |      \n",
+      " |      :type id: str\n",
+      " |      :param id: the id of an image\n",
+      " |      \n",
+      " |      :rtype dict\n",
+      " |      :return an image\n",
+      " |  \n",
+      " |  get(self, id: str) -> dict\n",
+      " |      Get an image by id\n",
+      " |      \n",
+      " |      :type id: str\n",
+      " |      :param id: the id of an image\n",
+      " |      \n",
+      " |      :rtype dict\n",
+      " |      :return an image\n",
+      " |  \n",
+      " |  help_description(self)\n",
+      " |      one line description for all commands\n",
+      " |  \n",
+      " |  list(self, **kwargs) -> Iterator\n",
+      " |      List images\n",
+      " |      \n",
+      " |      :type page: int\n",
+      " |      :param page: the page of all data\n",
+      " |      \n",
+      " |      :rtype Iterator\n",
+      " |      :return image iterator\n",
+      " |  \n",
+      " |  update(self, id: str, config: dict)\n",
+      " |  \n",
+      " |  ----------------------------------------------------------------------\n",
+      " |  Data and other attributes defined here:\n",
+      " |  \n",
+      " |  __abstractmethods__ = frozenset()\n",
+      " |  \n",
+      " |  ----------------------------------------------------------------------\n",
+      " |  Data descriptors inherited from primehub.Helpful:\n",
+      " |  \n",
+      " |  __dict__\n",
+      " |      dictionary for instance variables (if defined)\n",
+      " |  \n",
+      " |  __weakref__\n",
+      " |      list of weak references to the object (if defined)\n",
+      " |  \n",
+      " |  ----------------------------------------------------------------------\n",
+      " |  Methods inherited from primehub.Module:\n",
+      " |  \n",
+      " |  __init__(self, primehub: primehub.PrimeHub, **kwargs)\n",
+      " |      Initialize self.  See help(type(self)) for accurate signature.\n",
+      " |  \n",
+      " |  display(self, action: dict, value: Any)\n",
+      " |  \n",
+      " |  get_display(self) -> primehub.utils.display.Displayable\n",
+      " |  \n",
+      " |  ----------------------------------------------------------------------\n",
+      " |  Static methods inherited from primehub.Module:\n",
+      " |  \n",
+      " |  output(result: dict, object_path: str)\n",
+      " |      Give a dict {'data': {'a': {'b': 'c'}}}\n",
+      " |      we could get the c by the path a.b\n",
+      " |  \n",
+      " |  ----------------------------------------------------------------------\n",
+      " |  Data descriptors inherited from primehub.Module:\n",
+      " |  \n",
+      " |  current_group\n",
+      " |  \n",
+      " |  endpoint\n",
+      " |  \n",
+      " |  group_id\n",
+      " |  \n",
+      " |  group_name\n",
+      " |  \n",
+      " |  primehub_config\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "help(ph.admin.images)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "73eae411",
+   "metadata": {},
+   "source": [
+    "## Images management\n",
+    "\n",
+    "---\n",
+    "\n",
+    "\n",
+    "```\n",
+    "$ primehub admin images\n",
+    "\n",
+    "Usage: \n",
+    "  primehub admin images <command>\n",
+    "\n",
+    "Manage images\n",
+    "\n",
+    "Available Commands:\n",
+    "  create               Create an image\n",
+    "  delete               Delete an image by id\n",
+    "  get                  Get an image by id\n",
+    "  list                 List images\n",
+    "  update               Update the image\n",
+    "```\n",
+    "\n",
+    "---\n",
+    "\n",
+    "### Fields for creating or updating\n",
+    "\n",
+    "| field | required | type | description |\n",
+    "| --- | --- | --- | --- |\n",
+    "| name | required | string | it should be a valid resource name for kubernetes. `name` will be ignored when updating |\n",
+    "| displayName | optional | string | display name for the instance type |\n",
+    "| description | optional | string | |\n",
+    "| global | optional | boolean | when an instance type is global, it could be seen for each group |\n",
+    "| groups | optional | list of connected groups (dict) | please see the `connect` examples |\n",
+    "| cpuLimit | required | float | the maximum vCPU quantity. For example: `1` or `1.0` means 1 vCPU and `0.5` means half of vCPU |\n",
+    "| cpuRequest | optional | float | the initial vCPU quantity for CPU resource. cpuRequest can not be greater than cpuLimit |\n",
+    "| memoryLimit | required | float | the maximum Memory size. For example: `1.5` means `1.5 GB` memory |\n",
+    "| memoryRequest | optional | float | the initial Memory size. memoryRequest can not be greater than memoryLimit |\n",
+    "| gpuLimit | optional | int | the count of GPU when an instance allocated |\n",
+    "| tolerations | optional | dict | kubernetes pod toleration in an instance (Pod) |\n",
+    "| nodeSelector | optional | dict | kubernetes pod nodeSelector in an instance (Pod) |\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eea61de7",
+   "metadata": {},
+   "source": [
+    "## Examples"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9becc7e1",
+   "metadata": {},
+   "source": [
+    "You could find [more examples on our github](https://github.com/InfuseAI/primehub-python-sdk/blob/main/docs/CLI/admin/images.md)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "2f09c119",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[{'id': 'base',\n",
+       "  'name': 'base',\n",
+       "  'displayName': 'Base image',\n",
+       "  'description': 'base-notebook with python qq-1',\n",
+       "  'type': 'cpu',\n",
+       "  'isReady': True},\n",
+       " {'id': 'base-notebook',\n",
+       "  'name': 'base-notebook',\n",
+       "  'displayName': 'base-notebook',\n",
+       "  'description': 'base notebook',\n",
+       "  'type': 'both',\n",
+       "  'isReady': True},\n",
+       " {'id': 'bug',\n",
+       "  'name': 'bug',\n",
+       "  'displayName': 'bug',\n",
+       "  'description': '',\n",
+       "  'type': 'both',\n",
+       "  'isReady': True},\n",
+       " {'id': 'custom1',\n",
+       "  'name': 'custom1',\n",
+       "  'displayName': 'custom1',\n",
+       "  'description': None,\n",
+       "  'type': 'cpu',\n",
+       "  'isReady': True},\n",
+       " {'id': 'custom2',\n",
+       "  'name': 'custom2',\n",
+       "  'displayName': 'custom2',\n",
+       "  'description': None,\n",
+       "  'type': 'both',\n",
+       "  'isReady': True},\n",
+       " {'id': 'custom3',\n",
+       "  'name': 'custom3',\n",
+       "  'displayName': 'custom3',\n",
+       "  'description': None,\n",
+       "  'type': 'both',\n",
+       "  'isReady': True},\n",
+       " {'id': 'e1',\n",
+       "  'name': 'e1',\n",
+       "  'displayName': 'display1',\n",
+       "  'description': 'desc1',\n",
+       "  'type': 'both',\n",
+       "  'isReady': True},\n",
+       " {'id': 'img1',\n",
+       "  'name': 'img1',\n",
+       "  'displayName': 'IMG',\n",
+       "  'description': 'iiiimmmmggg',\n",
+       "  'type': 'cpu',\n",
+       "  'isReady': True},\n",
+       " {'id': 'p1',\n",
+       "  'name': 'p1',\n",
+       "  'displayName': 'p1',\n",
+       "  'description': '',\n",
+       "  'type': 'both',\n",
+       "  'isReady': True},\n",
+       " {'id': 'p2',\n",
+       "  'name': 'p2',\n",
+       "  'displayName': 'p2',\n",
+       "  'description': '',\n",
+       "  'type': 'both',\n",
+       "  'isReady': True},\n",
+       " {'id': 'p3',\n",
+       "  'name': 'p3',\n",
+       "  'displayName': 'p3',\n",
+       "  'description': '',\n",
+       "  'type': 'both',\n",
+       "  'isReady': True},\n",
+       " {'id': 'pytorch-1',\n",
+       "  'name': 'pytorch-1',\n",
+       "  'displayName': 'PyTorch 1.8.0 (Python 3.7)',\n",
+       "  'description': 'PyTorch 1.8.0 (Python 3.7)',\n",
+       "  'type': 'both',\n",
+       "  'isReady': True},\n",
+       " {'id': 'tf-1',\n",
+       "  'name': 'tf-1',\n",
+       "  'displayName': 'TensorFlow 1.15.4 (Python 3.7)',\n",
+       "  'description': 'TensorFlow 1.15.4 (Python 3.7)',\n",
+       "  'type': 'both',\n",
+       "  'isReady': True},\n",
+       " {'id': 'tf-2',\n",
+       "  'name': 'tf-2',\n",
+       "  'displayName': 'TensorFlow 2.5.0 (Python 3.7)',\n",
+       "  'description': 'TensorFlow 2.5.0 (Python 3.7)',\n",
+       "  'type': 'both',\n",
+       "  'isReady': True},\n",
+       " {'id': 'zzz',\n",
+       "  'name': 'zzz',\n",
+       "  'displayName': 'zzzzz',\n",
+       "  'description': '',\n",
+       "  'type': 'both',\n",
+       "  'isReady': True}]"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# List images\n",
+    "list(ph.admin.images.list())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "0961aebb",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'id': 'image-by-sdk'}"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Create an image\n",
+    "config = {\n",
+    "  \"name\": \"image-by-sdk\",\n",
+    "  \"displayName\": \"Learning how to create an image from SDK\",\n",
+    "  \"description\": \"base-notebook with python 3.7\",\n",
+    "  \"type\": \"both\",\n",
+    "  \"url\": \"infuseai/docker-stacks:base-notebook-63fdf50a\",\n",
+    "  \"urlForGpu\": \"infuseai/docker-stacks:base-notebook-63fdf50a-gpu\",\n",
+    "  \"global\": True\n",
+    "}\n",
+    "ph.admin.images.create(config)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "687b6b59",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'id': 'image-by-sdk',\n",
+       " 'name': 'image-by-sdk',\n",
+       " 'displayName': 'Learning how to create an image from SDK',\n",
+       " 'description': 'base-notebook with python 3.7, only cpu',\n",
+       " 'type': 'cpu',\n",
+       " 'url': 'infuseai/docker-stacks:base-notebook-63fdf50a',\n",
+       " 'urlForGpu': 'infuseai/docker-stacks:base-notebook-63fdf50a',\n",
+       " 'useImagePullSecret': None,\n",
+       " 'global': True,\n",
+       " 'groups': [],\n",
+       " 'isReady': True,\n",
+       " 'imageSpec': None,\n",
+       " 'jobStatus': None,\n",
+       " 'logEndpoint': 'https://hub.ctiml-ec2.aws.primehub.io/api/logs/images/image-by-sdk/job'}"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Update an image\n",
+    "update = {\n",
+    "  \"description\": \"base-notebook with python 3.7, only cpu\",\n",
+    "  \"type\": \"cpu\"\n",
+    "}\n",
+    "ph.admin.images.update(config['name'], update)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "1d1f177c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'id': 'image-by-sdk',\n",
+       " 'name': 'image-by-sdk',\n",
+       " 'displayName': 'Learning how to create an image from SDK',\n",
+       " 'description': 'base-notebook with python 3.7',\n",
+       " 'type': 'both',\n",
+       " 'url': 'infuseai/docker-stacks:base-notebook-63fdf50a',\n",
+       " 'urlForGpu': 'infuseai/docker-stacks:base-notebook-63fdf50a-gpu',\n",
+       " 'useImagePullSecret': '',\n",
+       " 'global': True,\n",
+       " 'groups': [],\n",
+       " 'isReady': True,\n",
+       " 'imageSpec': None,\n",
+       " 'jobStatus': None,\n",
+       " 'logEndpoint': 'https://hub.ctiml-ec2.aws.primehub.io/api/logs/images/image-by-sdk/job'}"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Get deatils by id\n",
+    "ph.admin.images.get(config['name'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3b08571c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Delete the instance type\n",
+    "ph.admin.images.delete(config['name'])"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/primehub/__init__.py
+++ b/primehub/__init__.py
@@ -217,6 +217,7 @@ class PrimeHub(object):
         self.register_dummy_command('admin', 'Commands for system administrator')
 
         # register admin commands
+        self.register_admin_command('admin_images', 'AdminImages', 'images')
         self.register_admin_command('admin_datasets', 'AdminDatasets', 'datasets')
         self.register_admin_command('admin_instancetypes', 'AdminInstanceTypes', 'instancetypes')
         self.register_admin_command('admin_users', 'AdminUsers', 'users')

--- a/primehub/admin_images.py
+++ b/primehub/admin_images.py
@@ -1,5 +1,5 @@
 import json
-from typing import Iterator, Dict, Any
+from typing import Iterator
 
 from primehub import Helpful, Module, cmd, primehub_load_config
 from primehub.utils import PrimeHubException, resource_not_found

--- a/primehub/admin_images.py
+++ b/primehub/admin_images.py
@@ -123,6 +123,11 @@ class AdminImages(Helpful, Module):
     def _valid_update(self, config, id):
         existing_config = self.get(id)
         if existing_config is not None:
+
+            # avoid updating 'urlForGpu' when no 'urlForGpu' in request
+            if existing_config.get('urlForGpu') and not config.get('urlForGpu'):
+                config['urlForGpu'] = existing_config['urlForGpu']
+
             validate(existing_config, True)
 
     @cmd(name='get', description='Get an image by id', return_required=True)

--- a/primehub/admin_images.py
+++ b/primehub/admin_images.py
@@ -1,0 +1,200 @@
+import json
+from typing import Iterator, Dict, Any
+
+from primehub import Helpful, Module, cmd, primehub_load_config
+from primehub.utils import PrimeHubException, resource_not_found
+from primehub.utils.optionals import file_flag
+from primehub.utils.validator import validate_name, validate_groups
+
+
+def _error_handler(response):
+    import re
+
+    if 'errors' in response:
+        message = [x for x in response['errors'] if 'message' in x]
+        if message:
+            message = message[0]['message']
+            result = re.findall(r'images.primehub.io "([^"]+)" not found', message)
+            if result:
+                resource_not_found('images', result[0], 'id')
+
+
+class AdminImages(Helpful, Module):
+
+    @cmd(name='create', description='Create an image', optionals=[('file', file_flag), ('from', str)])
+    def _create_cmd(self, **kwargs):
+        """
+        Create an image
+
+        :type file: str
+        :param file: The file path of the configurations
+
+        :rtype dict
+        :return The image
+        """
+        if kwargs.get('from', None):
+            return self.submit_from_schedule(kwargs['from'])
+
+        config = primehub_load_config(filename=kwargs.get('file', None))
+        if not config:
+            invalid_config('The configuration is required.')
+
+        return self.create(config)
+
+    def create(self, config):
+        """
+        Create an image
+
+        :type config: dict
+        :param config: The configurations for creating an image
+
+        :rtype dict
+        :return The image
+        """
+        payload = validate(config)
+
+        query = """
+        """
+
+        results = self.request({'payload': validate(payload)}, query)
+        if 'data' not in results:
+            return results
+        return
+
+    @cmd(name='update', description='Update the image', optionals=[('file', file_flag)])
+    def _update_cmd(self, id: str, **kwargs):
+        """
+        Update the image
+
+        :type id: str
+        :param id: the id of the image
+
+        :rtype: dict
+        :returns: the image
+        """
+        return self.update(id, primehub_load_config(filename=kwargs.get('file', None)))
+
+    def update(self, id: str, config: dict):
+        self._valid_update(config, id)
+
+        query = """
+        """
+
+        results = self.request({'where': {'id': id}, 'payload': config}, query, _error_handler)
+        if 'data' not in results:
+            return results
+
+        return
+
+    def _valid_update(self, config, id):
+        existing_config = self.get(id)
+        if existing_config is not None:
+            validate(existing_config, True)
+
+    @cmd(name='get', description='Get an image by id', return_required=True)
+    def get(self, id: str) -> dict:
+        """
+        Get an image by id
+
+        :type id: str
+        :param id: the id of an image
+
+        :rtype dict
+        :return an image
+        """
+        query = """
+        """
+
+        results = self.request({'where': {'id': id}}, query)
+        if 'data' not in results:
+            return results
+        return
+
+    @cmd(name='delete', description='Delete an image by id', return_required=True)
+    def delete(self, id):
+        """
+        Delete an image by id
+
+        :type id: str
+        :param id: the id of an image
+
+        :rtype dict
+        :return an image
+        """
+
+        query = """
+        """
+        results = self.request({'where': {'id': id}}, query)
+        if 'data' not in results:
+            return results
+        return
+
+    @cmd(name='list', description='List images', return_required=True, optionals=[('page', int)])
+    def list(self, **kwargs) -> Iterator:
+        """
+        List images
+
+        :type page: int
+        :param page: the page of all data
+
+        :rtype Iterator
+        :return image iterator
+        """
+        query = """
+        """
+        variables = {'page': 1}
+        page = kwargs.get('page', 0)
+        if page:
+            variables['page'] = page
+            results = self.request(variables, query)
+            for e in results['data']['imagesConnection']['edges']:
+                yield e['node']
+            return
+
+        page = 1
+        while True:
+            variables['page'] = page
+            results = self.request(variables, query)
+            if results['data']['imagesConnection']['edges']:
+                for e in results['data']['imagesConnection']['edges']:
+                    yield e['node']
+                page = page + 1
+            else:
+                break
+
+    def help_description(self):
+        return "Manage images"
+
+
+def required_field(field):
+    return f'{field} is required'
+
+
+def required_numeric_field(field):
+    return f'{field} must be an integer or a float type'
+
+
+def required_gt_0(field):
+    return f'{field} must be greater than zero'
+
+
+def required_int_field(field):
+    return f'{field} must be an integer type'
+
+
+def required_str_lengths_3_63(field):
+    return f'{field} value must a string and len(value) between 3 and 63'
+
+
+def validate(payload: dict, for_update=False):
+    if not for_update:
+        validate_name(payload)
+    validate_groups(payload)
+
+    return payload
+
+
+def invalid_config(message: str):
+    example = """
+    """.strip()
+    raise PrimeHubException(message + "\n\nExample:\n" + json.dumps(json.loads(example), indent=2))

--- a/primehub/admin_images.py
+++ b/primehub/admin_images.py
@@ -103,12 +103,44 @@ class AdminImages(Helpful, Module):
         :return an image
         """
         query = """
+        query ImageQuery($where: ImageWhereUniqueInput!) {
+          image(where: $where) {
+            id
+            name
+            displayName
+            description
+            type
+            url
+            urlForGpu
+            useImagePullSecret
+            global
+            groups {
+              id
+              name
+              displayName
+            }
+            isReady
+            imageSpec {
+              baseImage
+              pullSecret
+              packages {
+                apt
+                conda
+                pip
+              }
+            }
+            jobStatus {
+              phase
+            }
+            logEndpoint
+          }
+        }
         """
 
         results = self.request({'where': {'id': id}}, query)
         if 'data' not in results:
             return results
-        return
+        return results['data']['image']
 
     @cmd(name='delete', description='Delete an image by id', return_required=True)
     def delete(self, id):
@@ -123,11 +155,16 @@ class AdminImages(Helpful, Module):
         """
 
         query = """
+        mutation DeleteImageMutation($where: ImageWhereUniqueInput!) {
+          deleteImage(where: $where) {
+            id
+          }
+        }
         """
         results = self.request({'where': {'id': id}}, query)
         if 'data' not in results:
             return results
-        return
+        return results['data']['deleteImage']
 
     @cmd(name='list', description='List images', return_required=True, optionals=[('page', int)])
     def list(self, **kwargs) -> Iterator:
@@ -141,6 +178,30 @@ class AdminImages(Helpful, Module):
         :return image iterator
         """
         query = """
+        query ImagesQuery($page: Int, $where: ImageWhereInput, $orderBy: ImageOrderByInput) {
+          imagesConnection(
+            page: $page
+            orderBy: $orderBy
+            where: $where
+            mode: SYSTEM_ONLY
+          ) {
+            edges {
+              cursor
+              node {
+                id
+                name
+                displayName
+                description
+                type
+                isReady
+              }
+            }
+            pageInfo {
+              currentPage
+              totalPage
+            }
+          }
+        }
         """
         variables = {'page': 1}
         page = kwargs.get('page', 0)

--- a/primehub/admin_images.py
+++ b/primehub/admin_images.py
@@ -61,7 +61,7 @@ class AdminImages(Helpful, Module):
         results = self.request({'data': validate(payload)}, query)
         if 'data' not in results:
             return results
-        return
+        return results['data']['createImage']
 
     @cmd(name='update', description='Update the image', optionals=[('file', file_flag)])
     def _update_cmd(self, id: str, **kwargs):
@@ -118,7 +118,7 @@ class AdminImages(Helpful, Module):
         if 'data' not in results:
             return results
 
-        return
+        return results['data']['updateImage']
 
     def _valid_update(self, config, id):
         existing_config = self.get(id)
@@ -329,7 +329,13 @@ def validate_image_type(payload):
 def invalid_config(message: str):
     example = """
     {
-      "name": "test"
+      "name": "base",
+      "displayName": "Base image",
+      "description": "base-notebook with python 3.7",
+      "type": "both",
+      "url": "infuseai/docker-stacks:base-notebook-63fdf50a",
+      "urlForGpu": "infuseai/docker-stacks:base-notebook-63fdf50a-gpu",
+      "global": true
     }
     """.strip()
     raise PrimeHubException(message + "\n\nExample:\n" + json.dumps(json.loads(example), indent=2))

--- a/primehub/admin_images.py
+++ b/primehub/admin_images.py
@@ -80,7 +80,10 @@ class AdminImages(Helpful, Module):
         self._valid_update(config, id)
 
         query = """
-        mutation UpdateImageMutation($data: ImageUpdateInput!, $where: ImageWhereUniqueInput!) {
+        mutation UpdateImageMutation(
+          $data: ImageUpdateInput!
+          $where: ImageWhereUniqueInput!
+        ) {
           updateImage(data: $data, where: $where) {
             id
             name
@@ -217,7 +220,11 @@ class AdminImages(Helpful, Module):
         :return image iterator
         """
         query = """
-        query ImagesQuery($page: Int, $where: ImageWhereInput, $orderBy: ImageOrderByInput) {
+        query ImagesQuery(
+          $page: Int
+          $where: ImageWhereInput
+          $orderBy: ImageOrderByInput
+        ) {
           imagesConnection(
             page: $page
             orderBy: $orderBy

--- a/primehub/extras/templates/examples/admin/images.md
+++ b/primehub/extras/templates/examples/admin/images.md
@@ -5,11 +5,106 @@
 | name | required | string | it should be a valid resource name for kubernetes. `name` will be ignored when updating |
 | displayName | optional | string | |
 | description | optional | string | |
-| type | required | string | onf of ['cpu', 'gpu', 'both'] |
+| type | required | string | one of ['cpu', 'gpu', 'both'] |
 | global | optional | boolean |  |
 | groups | optional | object | |
 | url | optional | string | container image url |
 | urlForGpu | optional | string | container image url for GPU optimized |
-| imageSpec | optional | object | |
+| imageSpec | optional | object | the specification for customization |
 
+#### imageSpec Example
 
+> YOU MUST ENABLE AND CONFIGURE [CUSTOM IMAGE BUILD](https://docs.primehub.io/docs/getting_started/configure-image-builder)
+
+To use the imageSpec, you need an object like this structure:
+
+```json
+{
+  "baseImage": "jupyter/base-notebook",
+  "packages": {
+    "pip": [
+      "pytest"
+    ]
+  }
+}
+```
+
+* baseImage: a container url for the customization
+* packages: configure package managers and installation list
+    * pip
+    * apt
+    * conda
+
+`packages` is a dictionary and its keys should be one of `['apt', 'conda', 'pip']` and value should be a list for
+packages you want to install
+
+### Manage images by SDK
+
+First, you can find the example by `create` action:
+
+```
+$ primehub admin images create
+
+The configuration is required.
+
+Example:
+{
+  "name": "base",
+  "displayName": "Base image",
+  "description": "base-notebook with python 3.7",
+  "type": "both",
+  "url": "infuseai/docker-stacks:base-notebook-63fdf50a",
+  "urlForGpu": "infuseai/docker-stacks:base-notebook-63fdf50a-gpu",
+  "global": true
+}
+```
+
+Let's use it to create a new image:
+
+```
+$ primehub admin images create <<EOF
+{
+  "name": "my-first-image",
+  "displayName": "Learning how to create an image from SDK",
+  "description": "base-notebook with python 3.7",
+  "type": "both",
+  "url": "infuseai/docker-stacks:base-notebook-63fdf50a",
+  "urlForGpu": "infuseai/docker-stacks:base-notebook-63fdf50a-gpu",
+  "global": true
+}
+EOF
+```
+
+And check the result by `list` action
+
+```
+$ primehub admin images list
+
+id              name            displayName                               description                     type    isReady
+--------------  --------------  ----------------------------------------  ------------------------------  ------  ---------
+base-notebook   base-notebook   base-notebook                             base notebook                   both    True
+pytorch-1       pytorch-1       PyTorch 1.8.0 (Python 3.7)                PyTorch 1.8.0 (Python 3.7)      both    True
+tf-1            tf-1            TensorFlow 1.15.4 (Python 3.7)            TensorFlow 1.15.4 (Python 3.7)  both    True
+tf-2            tf-2            TensorFlow 2.5.0 (Python 3.7)             TensorFlow 2.5.0 (Python 3.7)   both    True
+my-first-image  my-first-image  Learning how to create an image from SDK  base-notebook with python 3.7   both    True
+```
+
+### Build a custom build
+
+```
+$ primehub admin images create <<EOF
+{
+  "name": "my-custom-image",
+  "type": "both",
+  "global": true,
+  "imageSpec": {
+    "baseImage": "jupyter/base-notebook",
+    "packages": {
+      "pip": [
+        "pytest"
+      ]
+    }
+  }
+}
+EOF
+```

--- a/primehub/extras/templates/examples/admin/images.md
+++ b/primehub/extras/templates/examples/admin/images.md
@@ -1,0 +1,22 @@
+### Fields for creating or updating
+
+TODO: update this
+
+| field | required | type | description |
+| --- | --- | --- | --- |
+| username | required | string | lower case alphanumeric characters, '-', '.', and underscores ("_") are allowed, and must start with a letter or numeric.` |
+| email | optional | string | a valid email |
+| firstName | optional | string | |
+| lastName | optional | string | |
+| isAdmin | optional | boolean | grant the administrator role to the user |
+| volumeCapacity | optional | int | customize the size of the user volume. unit: `GB`|
+| groups | optional | assign the user to groups | please see the `connect` examples |
+
+These fields are only used with email activation (only for `create`):
+
+| field | required | type | description |
+| --- | --- | --- | --- |
+| sendEmail | optional | boolean | send an activation email to the user. (it worked if the smtp was set)|
+| resetActions.set | optional | string[] | ask for actions, valid actions: `['VERIFY_EMAIL', 'UPDATE_PASSWORD']` |
+| expiresIn | optional | int | expired duration for the activation email |
+

--- a/primehub/extras/templates/examples/admin/images.md
+++ b/primehub/extras/templates/examples/admin/images.md
@@ -1,22 +1,15 @@
 ### Fields for creating or updating
 
-TODO: update this
-
 | field | required | type | description |
 | --- | --- | --- | --- |
-| username | required | string | lower case alphanumeric characters, '-', '.', and underscores ("_") are allowed, and must start with a letter or numeric.` |
-| email | optional | string | a valid email |
-| firstName | optional | string | |
-| lastName | optional | string | |
-| isAdmin | optional | boolean | grant the administrator role to the user |
-| volumeCapacity | optional | int | customize the size of the user volume. unit: `GB`|
-| groups | optional | assign the user to groups | please see the `connect` examples |
+| name | required | string | it should be a valid resource name for kubernetes. `name` will be ignored when updating |
+| displayName | optional | string | |
+| description | optional | string | |
+| type | required | string | onf of ['cpu', 'gpu', 'both'] |
+| global | optional | boolean |  |
+| groups | optional | object | |
+| url | optional | string | container image url |
+| urlForGpu | optional | string | container image url for GPU optimized |
+| imageSpec | optional | object | |
 
-These fields are only used with email activation (only for `create`):
-
-| field | required | type | description |
-| --- | --- | --- | --- |
-| sendEmail | optional | boolean | send an activation email to the user. (it worked if the smtp was set)|
-| resetActions.set | optional | string[] | ask for actions, valid actions: `['VERIFY_EMAIL', 'UPDATE_PASSWORD']` |
-| expiresIn | optional | int | expired duration for the activation email |
 

--- a/primehub/utils/validator.py
+++ b/primehub/utils/validator.py
@@ -13,7 +13,7 @@ def validate_name(payload: dict):
         raise PrimeHubException('name is required')
 
     matched: Union[str, Any, None] = re.match(
-        r'^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*',
+        r'^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$',
         payload.get('name'))
 
     # check formats

--- a/tests/test_admin_images.py
+++ b/tests/test_admin_images.py
@@ -36,11 +36,11 @@ class TestAdminImages(BaseTestCase):
 
         # check url* and imageSpec
         self.check_required({'name': 'image-1', 'url': 'image', 'imageSpec': {
-            'baseImage': 'jupyter/base-notebook', 'packages': {'pip': 'pytest'}
+            'baseImage': 'jupyter/base-notebook', 'packages': {'pip': ['pytest']}
         }}, "imageSpec cannot use with url and urlForGpu")
 
         self.check_required({'name': 'image-1', 'urlForGpu': 'image-for-gpu', 'imageSpec': {
-            'baseImage': 'jupyter/base-notebook', 'packages': {'pip': 'pytest'}
+            'baseImage': 'jupyter/base-notebook', 'packages': {'pip': ['pytest']}
         }}, "imageSpec cannot use with url and urlForGpu")
 
         # pass with valid configuration
@@ -51,7 +51,7 @@ class TestAdminImages(BaseTestCase):
 
         # pass with imageSpec
         validate({'name': 'my-image', 'imageSpec': {
-            'baseImage': 'jupyter/base-notebook', 'packages': {'pip': 'pytest'}
+            'baseImage': 'jupyter/base-notebook', 'packages': {'pip': ['pytest']}
         }})
 
     def test_image_spec_validator(self):

--- a/tests/test_admin_images.py
+++ b/tests/test_admin_images.py
@@ -1,0 +1,86 @@
+from primehub.admin_images import validate, validate_image_type, validate_image_spec
+from primehub.utils import PrimeHubException
+from tests import BaseTestCase
+
+
+class TestAdminImages(BaseTestCase):
+
+    def setUp(self) -> None:
+        super(TestAdminImages, self).setUp()
+
+    def check_required(self, cfg: dict, message: str, callback=None):
+        with self.assertRaises(PrimeHubException) as context:
+            if callback is None:
+                validate(cfg)
+            else:
+                callback(cfg)
+
+        self.assertTrue(isinstance(context.exception, PrimeHubException))
+        self.assertEqual(message, context.exception.args[0])
+
+    def test_validator(self):
+
+        # check empty username
+        self.check_required({}, 'name is required')
+        self.check_required({'name': 'aaaa_aaa'},
+                            "[name] should be lower case alphanumeric characters, '-' "
+                            "or '.', and must start and end with an alphanumeric character.")
+
+        # check invalid type valuez
+        self.check_required({'name': 'image-1', 'type': ''}, "type should be one of ['cpu', 'gpu', 'both']",
+                            validate_image_type)
+        self.check_required({'name': 'image-1', 'type': 'abc'}, "type should be one of ['cpu', 'gpu', 'both']",
+                            validate_image_type)
+
+        # TODO check secret useImagePullSecret after we support the "secrets" command group
+
+        # check url* and imageSpec
+        self.check_required({'name': 'image-1', 'url': 'image', 'imageSpec': {
+            'baseImage': 'jupyter/base-notebook', 'packages': {'pip': 'pytest'}
+        }}, "imageSpec cannot use with url and urlForGpu")
+
+        self.check_required({'name': 'image-1', 'urlForGpu': 'image-for-gpu', 'imageSpec': {
+            'baseImage': 'jupyter/base-notebook', 'packages': {'pip': 'pytest'}
+        }}, "imageSpec cannot use with url and urlForGpu")
+
+        # pass with valid configuration
+        validate({'name': 'my-image.org'})
+
+        # pass with url and urlForGpu
+        validate({'name': 'my-image', 'url': 'image-url', 'urlForGpu': 'image-gpu-url'})
+
+        # pass with imageSpec
+        validate({'name': 'my-image', 'imageSpec': {
+            'baseImage': 'jupyter/base-notebook', 'packages': {'pip': 'pytest'}
+        }})
+
+    def test_image_spec_validator(self):
+        def s(cfg: dict):
+            cfg['baseImage'] = 'jupyter/base-notebook'
+            return cfg
+
+        def c(payload: dict, expected: str):
+            self.check_required(payload, expected, validate_image_spec)
+
+        c({'name': 'image-1', 'imageSpec': {}}, "Invalid imageSpec: baseImage is required")
+        c({'name': 'image-1', 'imageSpec': s({})}, "Invalid imageSpec: packages is required")
+
+        c({'name': 'image-1', 'imageSpec': s({
+            'packages': []
+        })}, "Invalid imageSpec: packages is required")
+
+        c({'name': 'image-1', 'imageSpec': s({
+            'packages': {}
+        })}, "Invalid imageSpec: packages is required")
+
+        c({'name': 'image-1', 'imageSpec': s({
+            'packages': ['pytest']}
+        )}, "Invalid imageSpec: packages is a dict with {apt, pip, conda} keys and you have use at least one")
+
+        c({'name': 'image-1', 'imageSpec': s({
+            'packages': {'abc': ['abc']}
+        })}, "Invalid imageSpec: packages is a dict with {apt, pip, conda} keys and you have use at least one")
+
+        c({'name': 'image-1', 'imageSpec': s({
+            'packages': {'pip': 'pytest'}
+        })}, "Invalid imageSpec: packages values should be a list")


### PR DESCRIPTION
Add `images` to admin group

```
$ primehub admin images

Usage:
  primehub admin images <command>

Manage images

Available Commands:
  create               Create an image
  delete               Delete an image by id
  get                  Get an image by id
  list                 List images
  update               Update the image

Options:
  -h, --help           Show the help

Global Options:
  --config CONFIG      Change the path of the config file (Default: ~/.primehub/config.json)
  --endpoint ENDPOINT  Override the GraphQL API endpoint
  --token TOKEN        Override the API Token
  --group GROUP        Override the current group
  --json               Output the json format (output human-friendly format by default)
```