### PR TITLE
Handle API error messages

### DIFF
--- a/primehub/utils/display.py
+++ b/primehub/utils/display.py
@@ -164,7 +164,11 @@ class HumanFriendlyDisplay(Displayable):
         logger.debug('display-many')
 
         # 'module': 'primehub.jobs', 'func': 'list'
-        customized_key = "{}.{}".format(action['module'], action['func'])
+        if action:
+            customized_key = "{}.{}".format(action['module'], action['func'])
+        else:
+            customized_key = "fake-module.fake-function"
+
         if customized_key not in CUSTOMIZED_COLUMNS:
             print(tabulate(value, headers="keys"), file=file)
         else:

--- a/primehub/utils/http_client.py
+++ b/primehub/utils/http_client.py
@@ -34,6 +34,8 @@ class Client(object):
             raise ResponseException("Response is not valid JSON:\n{}".format(content))
         except ResourceNotFoundException as e:
             raise e
+        except GraphQLException as e:
+            raise e
         except BaseException as e:
             raise RequestException(e)
 


### PR DESCRIPTION
Handle errors from API request error messages

## Before fix

```
$ primehub files list /datasets
{'errors': [{'message': 'failed to list store objects', 'extensions': {'code': 'INTERNAL_ERROR'}}], 'data': None}
```

## After fix

```
$ primehub files list /datasets
message                       extensions
----------------------------  --------------------------
failed to list store objects  {'code': 'INTERNAL_ERROR'}

$ echo $?
1
```

```
$ primehub files list /datasets --json
[{"message": "failed to list store objects", "extensions": {"code": "INTERNAL_ERROR"}}]

$ echo $?
1
```