### PR TITLE
Support basic bash auto-completion

### DIFF
--- a/primehub-sdk-autocomplete.sh
+++ b/primehub-sdk-autocomplete.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+autoload -U bashcompinit
+
+_primehub() {
+  COMPREPLY=($(cur="${COMP_WORDS[COMP_CWORD]}" prev="${COMP_WORDS[COMP_CWORD-1]}" auto-primehub))
+}
+
+complete -F _primehub primehub

--- a/primehub/utils/completion.py
+++ b/primehub/utils/completion.py
@@ -1,0 +1,55 @@
+import os
+from ..cli import create_sdk
+from .decorators import find_actions
+
+variables = ('COMP_CWORD', 'COMP_LINE', 'COMP_POINT', 'COMP_WORDS', 'cur', 'prev')
+
+sdk = create_sdk()
+
+PRIMEHUB_AUTO_COMPLETION_LOG = (os.environ.get('PRIMEHUB_AUTO_COMPLETION_LOG', 'false') == 'true')
+
+
+def _debug_log(x):
+    if not PRIMEHUB_AUTO_COMPLETION_LOG:
+        return
+    with open('.auto-primehub.txt', 'a') as fh:
+        fh.write(x)
+        fh.write('\n')
+
+
+def _debug_variables():
+    if not PRIMEHUB_AUTO_COMPLETION_LOG:
+        return
+    with open('.auto-primehub.txt', 'a') as fh:
+        fh.write('-' * 16)
+        fh.write('\n')
+        for v in variables:
+            fh.write(f'{v}={os.environ.get(v)}\n')
+
+
+def auto_complete():
+    _debug_variables()
+
+    # first level command groups
+    # primehub <auto-completion>
+    # cur = os.environ.get('cur')
+    prev = os.environ.get('prev')
+    current_index = os.environ.get('COMP_CWORD')
+    if prev == 'primehub':
+        for k in sdk.commands:
+            if k.startswith(':'):
+                continue
+            print(k)
+        return
+
+    # primehub <current-group> <auto-completion>
+    if current_index == '2':
+        _debug_log(f'{prev} => {sdk.commands.keys()}')
+        if prev in sdk.commands:
+            for verb in find_actions(sdk.commands[prev]):
+                print(verb['name'])
+        pass
+
+
+if __name__ == '__main__':
+    auto_complete()

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,8 @@ setup(name='primehub-python-sdk',
       author_email='qrtt1@infuseai.io',
       url='https://github.com/InfuseAI/primehub-python-sdk',
       entry_points={
-          'console_scripts': ['primehub = primehub.cli:main', 'doc-primehub = primehub.extras.doc_generator:main']
+          'console_scripts': ['primehub = primehub.cli:main', 'doc-primehub = primehub.extras.doc_generator:main',
+                              'auto-primehub = primehub.utils.completion:auto_complete']
       },
       python_requires=">=3.6",
       packages=find_packages(),


### PR DESCRIPTION
## Usage

enable auto-completion 

```
$ source primehub-sdk-autocomplete.sh
```

trigger auto-completion

```
$ primehub<SPACE><TAB>
admin           apptemplates    deployments     groups          info            jobs            models          recurring-jobs  volumes
apps            config          files           images          instancetypes   me              notebooks       version
```

## Known issues

* admin groups not supported yet
* we have not looked up arguments dynamically yet