### PR TITLE
Fix improper print

### DIFF
--- a/primehub/config.py
+++ b/primehub/config.py
@@ -184,7 +184,7 @@ class OidcAuthenticationFlow:
             if 'api-token' in data:
                 self._save_config(config_from_console)
             else:
-                print(config_from_console)
+                print(config_from_console, file=self.primehub.stderr)
         except BaseException:
             raise
 
@@ -202,10 +202,10 @@ class OidcAuthenticationFlow:
         if os.path.exists(default_config_path):
             backup_path = os.path.expanduser(f'~/.primehub/config-{datetime.now().strftime("%Y%m%d%H%M%S")}.json')
             copyfile(default_config_path, backup_path)
-            print(f'Found old configuration, backup it to {backup_path}')
+            print(f'Found old configuration, backup it to {backup_path}', file=self.primehub.stderr)
 
         cfg.save(default_config_path)
-        print(f'PrimeHub SDK Config has been updated: {default_config_path}', file=self.primehub.stdout)
+        print(f'PrimeHub SDK Config has been updated: {default_config_path}', file=self.primehub.stderr)
 
     def _save_config(self, config_from_console: str):
         config_file_path = self._save_tmp_config(config_from_console)

--- a/primehub/files.py
+++ b/primehub/files.py
@@ -321,7 +321,7 @@ class Files(Helpful, Module):
                 if filter_func and filter_func(phfs_path):
                     self._warning_skip(phfs_path)
                     continue
-                print('[Uploading] ' + filepath + ' -> phfs://' + phfs_path)
+                print(f'[Uploading] {filepath} -> phfs://{phfs_path}', file=self.primehub.stderr)
                 response = self._execute_upload(endpoint, filepath, phfs_path)
                 response['phfs'] = phfs_path
                 response['file'] = filepath

--- a/primehub/recurring_jobs.py
+++ b/primehub/recurring_jobs.py
@@ -2,10 +2,12 @@ import json
 from typing import Iterator
 
 from primehub import Helpful, cmd, Module, primehub_load_config
-from primehub.utils import resource_not_found, PrimeHubException
+from primehub.utils import resource_not_found, PrimeHubException, create_logger
 from primehub.utils.optionals import file_flag
 from primehub.utils.permission import ask_for_permission
 from primehub.jobs import verify_basic_field, verify_timeout, invalid_field
+
+logger = create_logger('cmd-recurring-jobs')
 
 
 def _error_handler(response):
@@ -46,7 +48,7 @@ def verify_recurrence_options(config: dict):
         invalid_config('cron is required in custom type')
 
     if type_option != 'custom' and cron_val != '':
-        print('Notice: To make cron you defined effective, please use \'custom\' type')
+        logger.warning('Notice: To make cron you defined effective, please use \'custom\' type')
 
 
 def verify_recurrence(config: dict, for_update: bool = False):

--- a/tests/test_print.py
+++ b/tests/test_print.py
@@ -1,0 +1,39 @@
+import ast
+import os
+from unittest import TestCase
+
+
+class PrintChecker(ast.NodeTransformer):
+
+    def __init__(self, testutil: TestCase, filename: str):
+        self.testutil = testutil
+        self.filename = filename
+
+    def visit_Call(self, node):
+        if isinstance(node.func, ast.Name) and node.func.id == 'print':
+            file_kw_arg = [x for x in node.keywords if x.arg == 'file']
+            if len(file_kw_arg) == 0:
+                message = f'print should have "file" keyword arg: {self.filename}:{node.lineno}:{node.col_offset}\n'
+                message += 'fix it with file=primehub.stderr (it could be primehub.stdout)'
+                self.testutil.fail(message)
+        return node
+
+
+def source_contents():
+    project_dir = os.path.normpath(os.path.join(os.path.dirname(__file__), '../primehub'))
+    for root, dirs, files in os.walk(project_dir):
+        for f in files:
+            if f.endswith('.py'):
+                p = os.path.join(root, f)
+                with open(p, 'r') as fh:
+                    content = fh.read()
+                    yield p, content
+        break
+
+
+class PrintTest(TestCase):
+
+    def test_print_with_file_arg(self):
+        for filename, c in source_contents():
+            node = ast.parse(c)
+            PrintChecker(self, filename).visit(node)


### PR DESCRIPTION
Any `print` call in the sdk command should go with the `file` kwarg. 
In most case, it should be `self.primehub.stderr` to show error messages

1. fix improper print call
2. add a test to find out any print without the `file` kwarg (avoid the same problem in the future)