### PR TITLE
Add secrets command group

### DIFF
--- a/docs/CLI/admin/secrets.md
+++ b/docs/CLI/admin/secrets.md
@@ -1,0 +1,246 @@
+
+# <ADMIN> Primehub Secrets
+
+```
+Usage: 
+  primehub admin secrets <command>
+
+Manage secrets
+
+Available Commands:
+  create               Create a secret
+  delete               Delete a secret by id
+  get                  Get an secret by id
+  list                 List secrets
+  update               Update the secret
+
+Options:
+  -h, --help           Show the help
+
+Global Options:
+  --config CONFIG      Change the path of the config file (Default: ~/.primehub/config.json)
+  --endpoint ENDPOINT  Override the GraphQL API endpoint
+  --token TOKEN        Override the API Token
+  --group GROUP        Override the current group
+  --json               Output the json format (output human-friendly format by default)
+
+```
+
+
+### create
+
+Create a secret
+
+
+```
+primehub admin secrets create
+```
+ 
+
+* *(optional)* file: The file path of the configurations
+
+
+
+
+### delete
+
+Delete a secret by id
+
+
+```
+primehub admin secrets delete <id>
+```
+
+* id: the id of the secret
+ 
+
+
+
+
+### get
+
+Get an secret by id
+
+
+```
+primehub admin secrets get <id>
+```
+
+* id: the id of a secret
+ 
+
+
+
+
+### list
+
+List secrets
+
+
+```
+primehub admin secrets list
+```
+ 
+
+* *(optional)* page: the page of all data
+
+
+
+
+### update
+
+Update the secret
+
+
+```
+primehub admin secrets update <id>
+```
+
+* id: the id of the secret
+ 
+
+* *(optional)* file
+
+
+
+ 
+
+## Examples
+
+### Fields for creating or updating
+
+| field | required | type | description |
+| --- | --- | --- | --- |
+| name | required | string | The name of secret. It is only used when creating. |
+| type | required | string | one of ['opaque', 'kubernetes']. `opaque` is used for Git Sync Volume (SSH Public Key). `kubernetes` is used for Container Registry. |
+| displayName | optional | string | |
+
+* `type` can not be changed after created.
+
+Fields for  `opaque`
+
+| field | required | type | description |
+| --- | --- | --- | --- |
+| secret | conditional | string | when type is opaque, secret field become required for the SSH Public Key. |
+
+Fields for  `kubernetes`
+
+You should put container registry credentials to these fields:
+
+| field | required | type | description |
+| --- | --- | --- | --- |
+| registryHost | conditional | string |  |
+| username | conditional | string | |
+| password | conditional | string | |
+
+### Create secrets
+
+Create a secret for a Git Sync volume
+
+```
+primehub admin secrets create <<EOF
+{
+    "name": "dataset-secret",
+    "type": "opaque",
+    "secret": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDNoaA3Eo3CjCUBVe0SbrzsfOKS3REkfTkl28/drVVW5B+NXaXH7b3p7xijL8RTFj/wXQggACY+rcNtMbYewgxpZd1OZSf52JkqPKUfPHhvl3jGgeSSSg3fn6LAbAS8Vv/ywRJVsLVsjQelM1OH3E64Mznt0qpl/gO//T2CgRNHTwBseFMOf0BNfkd+gsP046pNxwqMlLfytrt6UC4+0Rb6ZWgVfd/Ij4xzK1AB/3mJ8HEdoCRWvoI/IElTzcEvvK3Vrx1KtSugpfywTXjSAyJhRWO7RsvgLvBgkuKRWFYuGlDo/X84hSClCFagPZ7LmvxIEgGFsUn6XFgia7VAO+WD nobody@local"
+}
+EOF
+```
+
+Create a secret for the Image Pull Secret usage
+
+```
+primehub admin secrets create <<EOF
+{
+    "name": "my-image-registry",
+    "type": "kubernetes",
+    "registryHost": "registry.gitlab.com",
+    "username": "nobody",
+    "password": "password"
+}
+EOF
+```
+
+### Query secrets
+
+Using `list` to find all secrets in the PrimeHub
+
+```
+$ primehub admin secrets list
+
+id                             name               displayName        type        registryHost         username
+-----------------------------  -----------------  -----------------  ----------  -------------------  ----------
+image-my-image-registry        my-image-registry  my-image-registry  kubernetes  registry.gitlab.com  nobody
+gitsync-secret-dataset-secret  dataset-secret     dataset-secret     opaque
+```
+
+Using `get` to get a secret
+
+```
+$ primehub admin secrets get image-my-image-registry
+
+id:             image-my-image-registry
+name:           my-image-registry
+displayName:    my-image-registry
+type:           kubernetes
+registryHost:   registry.gitlab.com
+username:       nobody
+password:       ******
+```
+
+```
+$ primehub admin secrets get gitsync-secret-dataset-secret
+
+id:             gitsync-secret-dataset-secret
+name:           dataset-secret
+displayName:    dataset-secret
+type:           opaque
+```
+
+### Update a secret
+
+Updating is similar with creating
+
+* update with the id of the secret
+* don't put `name` in the payload
+* `type` cannot not be changed
+
+```
+primehub admin secrets update image-my-image-registry <<EOF
+{
+    "type": "kubernetes",
+    "registryHost": "registry.gitlab.com",
+    "username": "somebody",
+    "password": "password"
+}
+EOF
+```
+
+After updating, **nobody** becomes **somebody**
+
+```
+$ primehub admin secrets list
+
+id                             name               displayName        type        registryHost         username
+-----------------------------  -----------------  -----------------  ----------  -------------------  ----------
+gitsync-secret-dataset-secret  dataset-secret     dataset-secret     opaque
+image-my-image-registry        my-image-registry  my-image-registry  kubernetes  registry.gitlab.com  somebody
+```
+
+### Delete a secret
+
+The deletion needs asking for the permission:
+
+```
+$ primehub admin secrets delete image-my-image-registry
+
+User rejects action [delete], please use the flag "--yes-i-really-mean-it" to allow the action.
+```
+
+If you really want to do it, adding `--yes-i-really-mean-it`
+
+```
+$ primehub admin secrets delete image-my-image-registry --yes-i-really-mean-it
+
+id:             image-my-image-registry
+```

--- a/docs/notebook/admin/secrets.ipynb
+++ b/docs/notebook/admin/secrets.ipynb
@@ -1,0 +1,210 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "3365d96c",
+   "metadata": {},
+   "source": [
+    "# [admin] Users command\n",
+    "\n",
+    "\n",
+    "The `users` command in `admin` scope could help you manage users.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0e684e90",
+   "metadata": {},
+   "source": [
+    "## Setup PrimeHub Python SDK\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2ed0bf22",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from primehub import PrimeHub, PrimeHubConfig\n",
+    "ph = PrimeHub(PrimeHubConfig())\n",
+    "\n",
+    "if ph.is_ready():\n",
+    "    print(\"PrimeHub Python SDK setup successfully\")\n",
+    "else:\n",
+    "    print(\"PrimeHub Python SDK couldn't get the group information, follow the 00-getting-started.ipynb to complete it\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3720ad82",
+   "metadata": {},
+   "source": [
+    "## Help documentation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2055801e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "help(ph.admin.secrets)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ac0e2516",
+   "metadata": {},
+   "source": [
+    "## Secrets management\n",
+    "\n",
+    "---\n",
+    "\n",
+    "\n",
+    "```\n",
+    "$ primehub admin secrets\n",
+    "\n",
+    "Usage:\n",
+    "  primehub admin secrets <command>\n",
+    "\n",
+    "Manage secrets\n",
+    "\n",
+    "Available Commands:\n",
+    "  create               Create a secret\n",
+    "  delete               Delete a secret by id\n",
+    "  get                  Get an secret by id\n",
+    "  list                 List secrets\n",
+    "  update               Update the secret\n",
+    "```\n",
+    "\n",
+    "---\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dcb77e3d",
+   "metadata": {},
+   "source": [
+    "## Examples"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b4eb5746",
+   "metadata": {},
+   "source": [
+    "You could find [more examples on our github](https://github.com/InfuseAI/primehub-python-sdk/blob/main/docs/CLI/admin/secrets.md)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "97458424",
+   "metadata": {},
+   "source": [
+    "### Fields for creating or updating\n",
+    "\n",
+    "| field | required | type | description |\n",
+    "| --- | --- | --- | --- |\n",
+    "| name | required | string | The name of secret. It is only used when creating. |\n",
+    "| type | required | string | one of ['opaque', 'kubernetes']. `opaque` is used for Git Sync Volume (SSH Public Key). `kubernetes` is used for Container Registry. |\n",
+    "| displayName | optional | string | |\n",
+    "\n",
+    "* `type` can not be changed after created.\n",
+    "\n",
+    "Fields for  `opaque`\n",
+    "\n",
+    "| field | required | type | description |\n",
+    "| --- | --- | --- | --- |\n",
+    "| secret | conditional | string | when type is opaque, secret field become required for the SSH Public Key. |\n",
+    "\n",
+    "Fields for  `kubernetes`\n",
+    "\n",
+    "You should put container registry credentials to these fields:\n",
+    "\n",
+    "| field | required | type | description |\n",
+    "| --- | --- | --- | --- |\n",
+    "| registryHost | conditional | string |  |\n",
+    "| username | conditional | string | |\n",
+    "| password | conditional | string | |\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "639e6281",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create secrets\n",
+    "secret = ph.admin.secrets.create(dict(name='create-secret-by-sdk', type='opaque', secret='keep it secret'))\n",
+    "secret"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ef3c1a91",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# List secrets\n",
+    "list(ph.admin.secrets.list())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6a1a1f49",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get the secret\n",
+    "ph.admin.secrets.get(secret['id'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bd697b8b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Delete the secret\n",
+    "print(f'delete secret by id: {secret[\"id\"]}')\n",
+    "ph.admin.secrets.delete(secret['id'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a0ffa881",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "PrimeHub SDK",
+   "language": "python",
+   "name": "myenv"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/primehub/__init__.py
+++ b/primehub/__init__.py
@@ -224,6 +224,7 @@ class PrimeHub(object):
         self.register_admin_command('admin_instancetypes', 'AdminInstanceTypes', 'instancetypes')
         self.register_admin_command('admin_users', 'AdminUsers', 'users')
         self.register_admin_command('admin_groups', 'AdminGroups', 'groups')
+        self.register_admin_command('admin_secrets', 'AdminSecrets', 'secrets')
 
         # initial
         self._ensure_config_details(config)

--- a/primehub/admin_secrets.py
+++ b/primehub/admin_secrets.py
@@ -1,0 +1,238 @@
+import json
+from typing import Iterator
+
+from primehub import Helpful, Module, cmd, primehub_load_config
+from primehub.utils import PrimeHubException
+from primehub.utils.optionals import file_flag
+from primehub.utils.permission import ask_for_permission
+from primehub.utils.validator import ValidationSpec
+
+
+def invalid_config(message: str):
+    example = """
+    {"name":"secret-1","type":"opaque","secret":"secret content"}
+    """.strip()
+    raise PrimeHubException(message + "\n\nExample:\n" + json.dumps(json.loads(example), indent=2))
+
+
+class AdminSecrets(Helpful, Module):
+
+    @cmd(name='list', description='List secrets', return_required=False, optionals=[('page', int)])
+    def list(self, **kwargs) -> Iterator:
+        """
+        List secrets
+
+        :type page: int
+        :param page: the page of all data
+
+        :rtype Iterator
+        :return secret iterator
+        """
+        query = """
+        query GetSecrets($page: Int) {
+          secretsConnection(page: $page) {
+            edges {
+              cursor
+              node {
+                id
+                ...SecretParts
+              }
+            }
+          }
+        }
+        fragment SecretParts on Secret {
+          id
+          name
+          displayName
+          type
+          registryHost
+          username
+        }
+        """
+        results = self.request({}, query)
+        if 'secretsConnection' in results['data']:
+            results = results['data']['secretsConnection']['edges']
+
+        # TODO does it support page?
+        # check would it support pagination
+        for e in results:
+            yield e['node']
+
+    @cmd(name='create', description='Create a secret', optionals=[('file', file_flag)])
+    def _create_cmd(self, **kwargs):
+        """
+        Create a secret
+
+        :type file: str
+        :param file: The file path of the configurations
+
+        :rtype dict
+        :return The user
+        """
+
+        config = primehub_load_config(filename=kwargs.get('file', None))
+        if not config:
+            invalid_config('The configuration is required.')
+        return self.create(config)
+
+    def create(self, config):
+        """
+        Create a secret
+
+        :type config: dict
+        :param config: The configurations for creating a secret
+
+        :rtype dict
+        :return The id of a secret
+        """
+
+        ValidationSpec("""
+        input SecretCreateInput {
+          name: ResourceID!
+          type: SecretType!
+          displayName: String
+          secret: String
+          registryHost: String
+          username: String
+          password: String
+        }
+        """).validate(config)
+
+        query = """
+        mutation CreateSecretMutation($payload: SecretCreateInput!) {
+          createSecret(data: $payload) {
+            id
+          }
+        }
+        """
+
+        results = self.request({'payload': config}, query)
+        if 'data' not in results:
+            return results
+        return results['data']['createSecret']
+
+    @cmd(name='update', description='Update the secret', optionals=[('file', file_flag)])
+    def _update_cmd(self, id: str, **kwargs):
+        """
+        Update the secret
+
+        :type id: str
+        :param id: the id of the secret
+
+        :rtype: dict
+        :returns: the secret
+        """
+        return self.update(id, primehub_load_config(filename=kwargs.get('file', None)))
+
+    def update(self, id: str, config: dict):
+        """
+        Update the secret
+
+        :type id: str
+        :param id: the id of the secret
+
+        :rtype: dict
+        :returns: the secret
+        """
+        if not config:
+            invalid_config('The configuration is required.')
+
+        query = """
+        mutation UpdateSecretMutation(
+          $payload: SecretUpdateInput!
+          $where: SecretWhereUniqueInput!
+        ) {
+          updateSecret(data: $payload, where: $where) {
+            id
+          }
+        }
+        """
+
+        ValidationSpec("""
+        input SecretUpdateInput {
+          displayName: String
+          type: SecretType
+          secret: String
+          registryHost: String
+          username: String
+          password: String
+        }
+        """).validate(config)
+
+        if config.get('type') and config.get('type') != self.get(id).get('type'):
+            raise PrimeHubException('[type] can not be changed')
+
+        results = self.request({'where': {'id': id}, 'payload': config}, query)
+        if 'data' not in results:
+            return results
+
+        return results['data']['updateSecret']
+
+    @cmd(name='get', description='Get an secret by id', return_required=True)
+    def get(self, id: str) -> dict:
+        """
+        Get an secret by id
+
+        :type id: str
+        :param id: the id of a secret
+
+        :rtype dict
+        :return the secret
+        """
+        query = """
+        query SecretQuery($where: SecretWhereUniqueInput!) {
+          secret(where: $where) {
+            id
+            ...SecretParts
+          }
+        }
+        fragment SecretParts on Secret {
+          id
+          name
+          displayName
+          type
+          registryHost
+          username
+          password
+        }
+        """
+
+        results = self.request({'where': {'id': id}}, query)
+        if 'data' not in results:
+            return results
+
+        result = results['data']['secret']
+
+        if result.get('type') == 'opaque':
+            del result['registryHost']
+            del result['username']
+            del result['password']
+        return result
+
+    @ask_for_permission
+    @cmd(name='delete', description='Delete a secret by id', return_required=True)
+    def delete(self, id: str, **kwargs) -> dict:
+        """
+        Delete a secret by id
+
+        :type id: str
+        :param id: the id of the secret
+
+        :rtype dict
+        :return the secret
+        """
+
+        query = """
+        mutation DeleteSecretMutation($where: SecretWhereUniqueInput!) {
+          deleteSecret(where: $where) {
+            id
+          }
+        }
+        """
+        results = self.request({'where': {'id': id}}, query)
+        if 'data' not in results:
+            return results
+        return results['data']['deleteSecret']
+
+    def help_description(self):
+        return "Manage secrets"

--- a/primehub/extras/templates/examples/admin/secrets.md
+++ b/primehub/extras/templates/examples/admin/secrets.md
@@ -1,0 +1,137 @@
+### Fields for creating or updating
+
+| field | required | type | description |
+| --- | --- | --- | --- |
+| name | required | string | The name of secret. It is only used when creating. |
+| type | required | string | one of ['opaque', 'kubernetes']. `opaque` is used for Git Sync Volume (SSH Public Key). `kubernetes` is used for Container Registry. |
+| displayName | optional | string | |
+
+* `type` can not be changed after created.
+
+Fields for  `opaque`
+
+| field | required | type | description |
+| --- | --- | --- | --- |
+| secret | conditional | string | when type is opaque, secret field become required for the SSH Public Key. |
+
+Fields for  `kubernetes`
+
+You should put container registry credentials to these fields:
+
+| field | required | type | description |
+| --- | --- | --- | --- |
+| registryHost | conditional | string |  |
+| username | conditional | string | |
+| password | conditional | string | |
+
+### Create secrets
+
+Create a secret for a Git Sync volume
+
+```
+primehub admin secrets create <<EOF
+{
+    "name": "dataset-secret",
+    "type": "opaque",
+    "secret": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDNoaA3Eo3CjCUBVe0SbrzsfOKS3REkfTkl28/drVVW5B+NXaXH7b3p7xijL8RTFj/wXQggACY+rcNtMbYewgxpZd1OZSf52JkqPKUfPHhvl3jGgeSSSg3fn6LAbAS8Vv/ywRJVsLVsjQelM1OH3E64Mznt0qpl/gO//T2CgRNHTwBseFMOf0BNfkd+gsP046pNxwqMlLfytrt6UC4+0Rb6ZWgVfd/Ij4xzK1AB/3mJ8HEdoCRWvoI/IElTzcEvvK3Vrx1KtSugpfywTXjSAyJhRWO7RsvgLvBgkuKRWFYuGlDo/X84hSClCFagPZ7LmvxIEgGFsUn6XFgia7VAO+WD nobody@local"
+}
+EOF
+```
+
+Create a secret for the Image Pull Secret usage
+
+```
+primehub admin secrets create <<EOF
+{
+    "name": "my-image-registry",
+    "type": "kubernetes",
+    "registryHost": "registry.gitlab.com",
+    "username": "nobody",
+    "password": "password"
+}
+EOF
+```
+
+### Query secrets
+
+Using `list` to find all secrets in the PrimeHub
+
+```
+$ primehub admin secrets list
+
+id                             name               displayName        type        registryHost         username
+-----------------------------  -----------------  -----------------  ----------  -------------------  ----------
+image-my-image-registry        my-image-registry  my-image-registry  kubernetes  registry.gitlab.com  nobody
+gitsync-secret-dataset-secret  dataset-secret     dataset-secret     opaque
+```
+
+Using `get` to get a secret
+
+```
+$ primehub admin secrets get image-my-image-registry
+
+id:             image-my-image-registry
+name:           my-image-registry
+displayName:    my-image-registry
+type:           kubernetes
+registryHost:   registry.gitlab.com
+username:       nobody
+password:       ******
+```
+
+```
+$ primehub admin secrets get gitsync-secret-dataset-secret
+
+id:             gitsync-secret-dataset-secret
+name:           dataset-secret
+displayName:    dataset-secret
+type:           opaque
+```
+
+### Update a secret
+
+Updating is similar with creating
+
+* update with the id of the secret
+* don't put `name` in the payload
+* `type` cannot not be changed
+
+```
+primehub admin secrets update image-my-image-registry <<EOF
+{
+    "type": "kubernetes",
+    "registryHost": "registry.gitlab.com",
+    "username": "somebody",
+    "password": "password"
+}
+EOF
+```
+
+After updating, **nobody** becomes **somebody**
+
+```
+$ primehub admin secrets list
+
+id                             name               displayName        type        registryHost         username
+-----------------------------  -----------------  -----------------  ----------  -------------------  ----------
+gitsync-secret-dataset-secret  dataset-secret     dataset-secret     opaque
+image-my-image-registry        my-image-registry  my-image-registry  kubernetes  registry.gitlab.com  somebody
+```
+
+### Delete a secret
+
+The deletion needs asking for the permission:
+
+```
+$ primehub admin secrets delete image-my-image-registry
+
+User rejects action [delete], please use the flag "--yes-i-really-mean-it" to allow the action.
+```
+
+If you really want to do it, adding `--yes-i-really-mean-it`
+
+```
+$ primehub admin secrets delete image-my-image-registry --yes-i-really-mean-it
+
+id:             image-my-image-registry
+```

--- a/primehub/utils/completion.py
+++ b/primehub/utils/completion.py
@@ -35,6 +35,7 @@ def auto_complete():
     # cur = os.environ.get('cur')
     prev = os.environ.get('prev')
     current_index = os.environ.get('COMP_CWORD')
+    command_line = os.environ.get('COMP_LINE')
     if prev == 'primehub':
         for k in sdk.commands:
             if k.startswith(':'):
@@ -45,10 +46,19 @@ def auto_complete():
     # primehub <current-group> <auto-completion>
     if current_index == '2':
         _debug_log(f'{prev} => {sdk.commands.keys()}')
-        if prev in sdk.commands:
+        if prev != 'admin' and prev in sdk.commands:
             for verb in find_actions(sdk.commands[prev]):
                 print(verb['name'])
-        pass
+        elif prev == 'admin':
+            for k in sdk.admin_commands:
+                if k.startswith(':'):
+                    continue
+                print(k)
+
+    if current_index == '3' and command_line.startswith('primehub admin '):
+        if prev in sdk.admin_commands:
+            for verb in find_actions(sdk.admin_commands[prev]):
+                print(verb['name'])
 
 
 if __name__ == '__main__':

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -16,8 +16,9 @@ class TestDatasets(BaseTestCase):
         self.assertEqual(message, context.exception.args[0])
 
     def test_creation_validator(self):
-        invalid_id_format_msg = 'id should be string type and lower case alphanumeric characters, \'-\' or \'.\', ' \
-                                'and must start and end with an alphanumeric character.'
+        invalid_id_format_msg = "id should be string type and lower case alphanumeric characters, '-' or '.'. " \
+                                "The value must start and end with an alphanumeric character " \
+                                "and its length of it should be less than 63."
 
         self.check_exception({}, 'id is a required field', validate_creation)
         self.check_exception({'id': 123}, invalid_id_format_msg, validate_creation)

--- a/tests/test_implementation_in_source_level.py
+++ b/tests/test_implementation_in_source_level.py
@@ -23,7 +23,15 @@ class TestAskForPermissionMethods(BaseTestCase):
                 # only cares about primehub package
                 continue
 
-            cmd_obj = self.sdk.commands[command_name]
+            cmd_obj = None
+            if command_name in self.sdk.commands:
+                cmd_obj = self.sdk.commands[command_name]
+            elif command_name in self.sdk.admin_commands:
+                cmd_obj = self.sdk.admin_commands[command_name]
+
+            if cmd_obj is None:
+                continue
+
             method = getattr(cmd_obj, method_name)
 
             # check the "**kwargs" in the last parameter


### PR DESCRIPTION
## Admin

```
$ primehub admin secrets
Usage:
  primehub admin secrets <command>

Manage secrets

Available Commands:
  create               Create a secret
  delete               Delete a secret by id
  get                  Get an secret by id
  list                 List secrets
  update               Update the secret

Options:
  -h, --help           Show the help

Global Options:
  --config CONFIG      Change the path of the config file (Default: ~/.primehub/config.json)
  --endpoint ENDPOINT  Override the GraphQL API endpoint
  --token TOKEN        Override the API Token
  --group GROUP        Override the current group
  --json               Output the json format (output human-friendly format by default)
```