### PR TITLE
Add "secrets" user commands

### DIFF
--- a/docs/CLI/secrets.md
+++ b/docs/CLI/secrets.md
@@ -1,0 +1,80 @@
+
+# Primehub Secrets
+
+```
+Usage: 
+  primehub secrets <command>
+
+Get a secret or list secrets
+
+Available Commands:
+  get                  Get a secret by id
+  list                 List secrets
+
+Options:
+  -h, --help           Show the help
+
+Global Options:
+  --config CONFIG      Change the path of the config file (Default: ~/.primehub/config.json)
+  --endpoint ENDPOINT  Override the GraphQL API endpoint
+  --token TOKEN        Override the API Token
+  --group GROUP        Override the current group
+  --json               Output the json format (output human-friendly format by default)
+
+```
+
+
+### get
+
+Get a secret by id
+
+
+```
+primehub secrets get <id>
+```
+
+* id: the id of a secret
+ 
+
+
+
+
+### list
+
+List secrets
+
+
+```
+primehub secrets list
+```
+ 
+
+
+
+ 
+
+## Examples
+
+### Query secrets
+
+`secrets` command is used for querying secrets. You will use `id` with features that support **image pull secret**, such as the `Deployments`. 
+
+Find all secrets with `list` command:
+
+```
+$ primehub secrets list
+
+id              name      type
+--------------  --------  ----------
+image-example1  example1  kubernetes
+```
+
+Get a secret with `get` command:
+
+```
+$ primehub secrets get image-example1
+
+id:             image-example1
+name:           example1
+type:           kubernetes
+```

--- a/docs/notebook/secrets.ipynb
+++ b/docs/notebook/secrets.ipynb
@@ -2,19 +2,19 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "4e2a2222",
+   "id": "6f94585c",
    "metadata": {},
    "source": [
-    "# Groups command\n",
+    "# Secrets command\n",
     "\n",
     "### Introduction\n",
     "\n",
-    "Groups command can show the available groups for your account.\n"
+    "Secrets command can show secret information. You will use the `id` with features that support **Image Pull Secret**.\n"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "b41b337d",
+   "id": "e035ff8a",
    "metadata": {},
    "source": [
     "## Setup PrimeHub Python SDK\n"
@@ -23,7 +23,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2d22406f",
+   "id": "14d61c20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -38,7 +38,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "15baf8f0",
+   "id": "99b72e74",
    "metadata": {},
    "source": [
     "## Help documentation"
@@ -47,16 +47,16 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3e0ba57d",
+   "id": "5c19aff9",
    "metadata": {},
    "outputs": [],
    "source": [
-    "help(ph.groups)"
+    "help(ph.secrets)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "b0a314a8",
+   "id": "fa526193",
    "metadata": {},
    "source": [
     "## Examples"
@@ -65,24 +65,34 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "26c345f4",
+   "id": "99019b63",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Get a group\n",
-    "ph.groups.get('devteam')"
+    "# List all secrets\n",
+    "secrets = list(ph.secrets.list())\n",
+    "secrets"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e983f14d",
+   "id": "40162ded",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# List effective group\n",
-    "ph.groups.list()"
+    "# Get a secret\n",
+    "id = secrets[0]['id'] if secrets else None\n",
+    "ph.secrets.get(id)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e97cc2f6",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/primehub/__init__.py
+++ b/primehub/__init__.py
@@ -216,6 +216,7 @@ class PrimeHub(object):
         self.register_command('apps', 'Apps')
         self.register_command('models', 'Models')
         self.register_command('datasets', 'Datasets')
+        self.register_command('secrets', 'Secrets')
         self.register_dummy_command('admin', 'Commands for system administrator')
 
         # register admin commands

--- a/primehub/extras/templates/examples/secrets.md
+++ b/primehub/extras/templates/examples/secrets.md
@@ -1,0 +1,23 @@
+### Query secrets
+
+`secrets` command is used for querying secrets. You will use `id` with features that support **image pull secret**, such as the `Deployments`. 
+
+Find all secrets with `list` command:
+
+```
+$ primehub secrets list
+
+id              name      type
+--------------  --------  ----------
+image-example1  example1  kubernetes
+```
+
+Get a secret with `get` command:
+
+```
+$ primehub secrets get image-example1
+
+id:             image-example1
+name:           example1
+type:           kubernetes
+```

--- a/primehub/secrets.py
+++ b/primehub/secrets.py
@@ -1,0 +1,49 @@
+from typing import Optional
+
+from primehub import Helpful, cmd, Module
+
+
+class Secrets(Helpful, Module):
+    """
+    Query secrets for Image Pull Secrets
+    """
+
+    @cmd(name='list', description='List secrets')
+    def list(self) -> list:
+        """
+        List secrets
+
+        :rtype: list
+        :returns: secrets
+        """
+        query = """
+        {
+          secrets(where: { ifDockerConfigJson: true }) {
+            id
+            name
+            type
+          }
+        }
+        """
+        results = self.request({}, query)
+        return results['data']['secrets']
+
+    @cmd(name='get', description='Get a secret by id', return_required=True)
+    def get(self, id: str) -> Optional[dict]:
+        """
+        Get the secret by id
+
+        :type id: str
+        :param id: the id of a secret
+
+        :rtype: Optional[dict]
+        :returns: a secret
+        """
+        secret = self.list()
+        s = [x for x in secret if x['id'] == id]
+        if s:
+            return s[0]
+        return None
+
+    def help_description(self):
+        return "Get a secret or list secrets"


### PR DESCRIPTION
```
$ primehub secrets

Usage:
  primehub secrets <command>

Get a secret or list secrets

Available Commands:
  get                  Get a secret by id
  list                 List secrets

Options:
  -h, --help           Show the help

Global Options:
  --config CONFIG      Change the path of the config file (Default: ~/.primehub/config.json)
  --endpoint ENDPOINT  Override the GraphQL API endpoint
  --token TOKEN        Override the API Token
  --group GROUP        Override the current group
  --json               Output the json format (output human-friendly format by default)

```