### PR TITLE
Admin groups with resources: images, instancetypes, volumes, users

### DIFF
--- a/docs/CLI/admin/groups.md
+++ b/docs/CLI/admin/groups.md
@@ -8,30 +8,51 @@ Usage:
 Manage groups
 
 Available Commands:
-  connect-image        Make the image join the group
-  connect-user         Add the user to the group
-  create               Create a group
-  create-image         Add the image to the group
-  delete               Delete the group by id
-  disconnect-image     Make the image leave the group
-  disconnect-user      Remove the user from the group
-  get                  Get the group info by id
-  list                 List groups
-  list-images          List images in the group
-  list-users           List users in the group
-  update               Update the group
+  connect-image         Make the image join the group
+  connect-image         Make the image join the group
+  connect-user          Add the user to the group
+  create                Create a group
+  create-image          Add the image to the group
+  create-instancetype   Add the image to the group
+  delete                Delete the group by id
+  disconnect-image      Make the image leave the group
+  disconnect-instancetype
+                        Make the image leave the group
+  disconnect-user       Remove the user from the group
+  get                   Get the group info by id
+  list                  List groups
+  list-images           List images in the group
+  list-instancetypes    List images in the group
+  list-users            List users in the group
+  update                Update the group
 
 Options:
-  -h, --help           Show the help
+  -h, --help            Show the help
 
 Global Options:
-  --config CONFIG      Change the path of the config file (Default: ~/.primehub/config.json)
-  --endpoint ENDPOINT  Override the GraphQL API endpoint
-  --token TOKEN        Override the API Token
-  --group GROUP        Override the current group
-  --json               Output the json format (output human-friendly format by default)
+  --config CONFIG       Change the path of the config file (Default: ~/.primehub/config.json)
+  --endpoint ENDPOINT   Override the GraphQL API endpoint
+  --token TOKEN         Override the API Token
+  --group GROUP         Override the current group
+  --json                Output the json format (output human-friendly format by default)
 
 ```
+
+
+### connect-image
+
+Make the image join the group
+
+
+```
+primehub admin groups connect-image <group_id> <instancetype_id>
+```
+
+* group_id: The group id
+* instancetype_id
+ 
+
+
 
 
 ### connect-image
@@ -100,6 +121,23 @@ primehub admin groups create-image <group_id>
 
 
 
+### create-instancetype
+
+Add the image to the group
+
+
+```
+primehub admin groups create-instancetype <group_id>
+```
+
+* group_id: The group id
+ 
+
+* *(optional)* file: The file path of the configurations
+
+
+
+
 ### delete
 
 Delete the group by id
@@ -126,6 +164,22 @@ primehub admin groups disconnect-image <group_id> <image_id>
 
 * group_id: The group id
 * image_id: The image id
+ 
+
+
+
+
+### disconnect-instancetype
+
+Make the image leave the group
+
+
+```
+primehub admin groups disconnect-instancetype <group_id> <instancetype_id>
+```
+
+* group_id: The group id
+* instancetype_id: The instanceType id
  
 
 
@@ -186,6 +240,21 @@ List images in the group
 
 ```
 primehub admin groups list-images <group_id>
+```
+
+* group_id: The group id
+ 
+
+
+
+
+### list-instancetypes
+
+List images in the group
+
+
+```
+primehub admin groups list-instancetypes <group_id>
 ```
 
 * group_id: The group id

--- a/docs/CLI/admin/groups.md
+++ b/docs/CLI/admin/groups.md
@@ -8,22 +8,26 @@ Usage:
 Manage groups
 
 Available Commands:
-  connect-image         Make the image join the group
+  connect-image         Make the instanceType join the group
   connect-image         Make the image join the group
   connect-user          Add the user to the group
+  connect-volume        Make the volume join the group
   create                Create a group
   create-image          Add the image to the group
-  create-instancetype   Add the image to the group
+  create-instancetype   Create a new instanceType and connect it to the group
+  create-volume         Create a new volume and connect it to the group
   delete                Delete the group by id
   disconnect-image      Make the image leave the group
   disconnect-instancetype
-                        Make the image leave the group
+                        Make the instanceType leave the group
   disconnect-user       Remove the user from the group
+  disconnect-volume     Make the volume leave the group
   get                   Get the group info by id
   list                  List groups
   list-images           List images in the group
-  list-instancetypes    List images in the group
+  list-instancetypes    List instanceTypes in the group
   list-users            List users in the group
+  list-volumes          List volumes in the group
   update                Update the group
 
 Options:
@@ -41,7 +45,7 @@ Global Options:
 
 ### connect-image
 
-Make the image join the group
+Make the instanceType join the group
 
 
 ```
@@ -89,6 +93,22 @@ primehub admin groups connect-user <group_id> <user_id>
 
 
 
+### connect-volume
+
+Make the volume join the group
+
+
+```
+primehub admin groups connect-volume <group_id> <volume_id>
+```
+
+* group_id: The group id
+* volume_id: The volume id
+ 
+
+
+
+
 ### create
 
 Create a group
@@ -123,11 +143,28 @@ primehub admin groups create-image <group_id>
 
 ### create-instancetype
 
-Add the image to the group
+Create a new instanceType and connect it to the group
 
 
 ```
 primehub admin groups create-instancetype <group_id>
+```
+
+* group_id: The group id
+ 
+
+* *(optional)* file: The file path of the configurations
+
+
+
+
+### create-volume
+
+Create a new volume and connect it to the group
+
+
+```
+primehub admin groups create-volume <group_id>
 ```
 
 * group_id: The group id
@@ -171,7 +208,7 @@ primehub admin groups disconnect-image <group_id> <image_id>
 
 ### disconnect-instancetype
 
-Make the image leave the group
+Make the instanceType leave the group
 
 
 ```
@@ -199,6 +236,22 @@ primehub admin groups disconnect-user <group_id> <user_id>
  
 
 * *(optional)* disable_group_admin
+
+
+
+
+### disconnect-volume
+
+Make the volume leave the group
+
+
+```
+primehub admin groups disconnect-volume <group_id> <volume_id>
+```
+
+* group_id: The group id
+* volume_id: The volume id
+ 
 
 
 
@@ -250,7 +303,7 @@ primehub admin groups list-images <group_id>
 
 ### list-instancetypes
 
-List images in the group
+List instanceTypes in the group
 
 
 ```
@@ -273,6 +326,21 @@ primehub admin groups list-users <group_id>
 ```
 
 * group_id: the group id
+ 
+
+
+
+
+### list-volumes
+
+List volumes in the group
+
+
+```
+primehub admin groups list-volumes <group_id>
+```
+
+* group_id: The group id
  
 
 

--- a/docs/CLI/admin/groups.md
+++ b/docs/CLI/admin/groups.md
@@ -8,8 +8,8 @@ Usage:
 Manage groups
 
 Available Commands:
-  connect-image         Make the instanceType join the group
   connect-image         Make the image join the group
+  connect-instancetype  Make the instanceType join the group
   connect-user          Add the user to the group
   connect-volume        Make the volume join the group
   create                Create a group
@@ -45,22 +45,6 @@ Global Options:
 
 ### connect-image
 
-Make the instanceType join the group
-
-
-```
-primehub admin groups connect-image <group_id> <instancetype_id>
-```
-
-* group_id: The group id
-* instancetype_id
- 
-
-
-
-
-### connect-image
-
 Make the image join the group
 
 
@@ -70,6 +54,22 @@ primehub admin groups connect-image <group_id> <image_id>
 
 * group_id: The group id
 * image_id: The image id
+ 
+
+
+
+
+### connect-instancetype
+
+Make the instanceType join the group
+
+
+```
+primehub admin groups connect-instancetype <group_id> <instancetype_id>
+```
+
+* group_id: The group id
+* instancetype_id: The instanceType id
  
 
 

--- a/docs/CLI/admin/groups.md
+++ b/docs/CLI/admin/groups.md
@@ -9,10 +9,14 @@ Manage groups
 
 Available Commands:
   add-user             Add the user to the group
+  connect-image        Make the image join the group
   create               Create a group
+  create-image         Add the image to the group
   delete               Delete the group by id
+  disconnect-image     Make the image leave the group
   get                  Get the group info by id
   list                 List groups
+  list-images          List images in the group
   list-users           List users in the group
   remove-user          Remove the user from the group
   update               Update the group
@@ -48,6 +52,22 @@ primehub admin groups add-user <group_id> <user_id>
 
 
 
+### connect-image
+
+Make the image join the group
+
+
+```
+primehub admin groups connect-image <group_id> <image_id>
+```
+
+* group_id: The group id
+* image_id: The image id
+ 
+
+
+
+
 ### create
 
 Create a group
@@ -63,6 +83,23 @@ primehub admin groups create
 
 
 
+### create-image
+
+Add the image to the group
+
+
+```
+primehub admin groups create-image <group_id>
+```
+
+* group_id: The group id
+ 
+
+* *(optional)* file: The file path of the configurations
+
+
+
+
 ### delete
 
 Delete the group by id
@@ -73,6 +110,22 @@ primehub admin groups delete <id>
 ```
 
 * id: the group id
+ 
+
+
+
+
+### disconnect-image
+
+Make the image leave the group
+
+
+```
+primehub admin groups disconnect-image <group_id> <image_id>
+```
+
+* group_id: The group id
+* image_id: The image id
  
 
 
@@ -104,6 +157,21 @@ primehub admin groups list
  
 
 * *(optional)* page: the page of all data
+
+
+
+
+### list-images
+
+List images in the group
+
+
+```
+primehub admin groups list-images <group_id>
+```
+
+* group_id: The group id
+ 
 
 
 

--- a/docs/CLI/admin/groups.md
+++ b/docs/CLI/admin/groups.md
@@ -8,17 +8,17 @@ Usage:
 Manage groups
 
 Available Commands:
-  add-user             Add the user to the group
   connect-image        Make the image join the group
+  connect-user         Add the user to the group
   create               Create a group
   create-image         Add the image to the group
   delete               Delete the group by id
   disconnect-image     Make the image leave the group
+  disconnect-user      Remove the user from the group
   get                  Get the group info by id
   list                 List groups
   list-images          List images in the group
   list-users           List users in the group
-  remove-user          Remove the user from the group
   update               Update the group
 
 Options:
@@ -34,24 +34,6 @@ Global Options:
 ```
 
 
-### add-user
-
-Add the user to the group
-
-
-```
-primehub admin groups add-user <group_id> <user_id>
-```
-
-* group_id: the group id
-* user_id: the user id
- 
-
-* *(optional)* enable_group_admin
-
-
-
-
 ### connect-image
 
 Make the image join the group
@@ -64,6 +46,24 @@ primehub admin groups connect-image <group_id> <image_id>
 * group_id: The group id
 * image_id: The image id
  
+
+
+
+
+### connect-user
+
+Add the user to the group
+
+
+```
+primehub admin groups connect-user <group_id> <user_id>
+```
+
+* group_id: the group id
+* user_id: the user id
+ 
+
+* *(optional)* enable_group_admin
 
 
 
@@ -131,6 +131,24 @@ primehub admin groups disconnect-image <group_id> <image_id>
 
 
 
+### disconnect-user
+
+Remove the user from the group
+
+
+```
+primehub admin groups disconnect-user <group_id> <user_id>
+```
+
+* group_id: the group id
+* user_id: the user id
+ 
+
+* *(optional)* disable_group_admin
+
+
+
+
 ### get
 
 Get the group info by id
@@ -187,24 +205,6 @@ primehub admin groups list-users <group_id>
 
 * group_id: the group id
  
-
-
-
-
-### remove-user
-
-Remove the user from the group
-
-
-```
-primehub admin groups remove-user <group_id> <user_id>
-```
-
-* group_id: the group id
-* user_id: the user id
- 
-
-* *(optional)* disable_group_admin
 
 
 
@@ -349,14 +349,14 @@ id                                    username    group_admin
 c634f8c9-d22e-4ead-bfa2-21ed018f6029  phadmin     True
 ```
 
-`add-user` and `remove-user` have same arguments to add or remove a user from the group,
+`connect-user` and `disconnect-user` have same arguments to add or remove a user from the group,
 but they are also do the group-admin enabling and disable.
 
 You can add an existing user with `--enable_group_admin` to added the group admin permission:
 
 ```
-$ primehub admin groups add-user 149f4cb6-e8d1-44e8-93d4-3a77f46ac682 698da31d-2ef8-476d-9d56-6275a949402c --enable_group_admin
+$ primehub admin groups connect-user 149f4cb6-e8d1-44e8-93d4-3a77f46ac682 698da31d-2ef8-476d-9d56-6275a949402c --enable_group_admin
 ```
 
-The permission can disable with `remove-user` and `--disable_group_admin`. When `--disable_group_admin` has set,
+The permission can disable with `disconnect-user` and `--disable_group_admin`. When `--disable_group_admin` has set,
 removal operation will only remove the permission not the user.

--- a/docs/CLI/admin/groups.md
+++ b/docs/CLI/admin/groups.md
@@ -164,10 +164,11 @@ Create a new volume and connect it to the group
 
 
 ```
-primehub admin groups create-volume <group_id>
+primehub admin groups create-volume <group_id> <writable>
 ```
 
 * group_id: The group id
+* writable: Set the writable for the connection
  
 
 * *(optional)* file: The file path of the configurations

--- a/primehub/admin_groups.py
+++ b/primehub/admin_groups.py
@@ -164,7 +164,8 @@ def apply_auto_fill(config: dict):
 
 class AdminGroupsVolumes(HTTPSupport):
 
-    @cmd(name='create-volume', description='Create a new volume and connect it to the group', optionals=[('file', file_flag)])
+    @cmd(name='create-volume', description='Create a new volume and connect it to the group',
+         optionals=[('file', file_flag)])
     def _create_volume(self, group_id: str, **kwargs):
         """
         Create a new volume and connect it to the group
@@ -298,7 +299,8 @@ class AdminGroupsVolumes(HTTPSupport):
 
 class AdminGroupsInstanceTypes(HTTPSupport):
 
-    @cmd(name='create-instancetype', description='Create a new instanceType and connect it to the group', optionals=[('file', file_flag)])
+    @cmd(name='create-instancetype', description='Create a new instanceType and connect it to the group',
+         optionals=[('file', file_flag)])
     def _create_instancetype(self, group_id: str, **kwargs):
         """
         Create a new instanceType and connect it to the group

--- a/primehub/admin_groups.py
+++ b/primehub/admin_groups.py
@@ -166,12 +166,15 @@ class AdminGroupsVolumes(HTTPSupport):
 
     @cmd(name='create-volume', description='Create a new volume and connect it to the group',
          optionals=[('file', file_flag)])
-    def _create_volume(self, group_id: str, **kwargs):
+    def _create_volume(self, group_id: str, writable: bool, **kwargs):
         """
         Create a new volume and connect it to the group
 
         :type group_id: str
         :param group_id: The group id
+
+        :type writable: bool
+        :param writable: Set the writable for the connection
 
         :type file: str
         :param file: The file path of the configurations
@@ -185,14 +188,17 @@ class AdminGroupsVolumes(HTTPSupport):
             from primehub.admin_volumes import invalid_config as volume_invalid_config
             volume_invalid_config('The configuration is required.')
 
-        return self.create_volume(group_id, config)
+        return self.create_volume(group_id, writable, config)
 
-    def create_volume(self, group_id: str, config: Dict) -> Dict:
+    def create_volume(self, group_id: str, writable: bool, config: Dict) -> Dict:
         """
         Create a new volume and connect it to the group
 
         :type group_id: str
         :param group_id: The group id
+
+        :type writable: bool
+        :param writable: Set the writable for the connection
 
         :type config: dict
         :param config: The configurations for creating an instanceType
@@ -203,9 +209,9 @@ class AdminGroupsVolumes(HTTPSupport):
 
         # assign the connected group
         config['global'] = False
-        config['groups'] = [dict(id=group_id)]
+        config['groups'] = dict(connect=[dict(id=group_id, writable=writable)])
 
-        return self.primehub.admin_instancetypes.create(config)
+        return self.primehub.admin_volumes.create(config)
 
     @cmd(name='disconnect-volume', description='Make the volume leave the group')
     def disconnect_volume(self, group_id: str, volume_id: str) -> Dict:
@@ -338,7 +344,7 @@ class AdminGroupsInstanceTypes(HTTPSupport):
 
         # assign the connected group
         config['global'] = False
-        config['groups'] = [dict(id=group_id)]
+        config['groups'] = dict(connect=[dict(id=group_id)])
 
         return self.primehub.admin_instancetypes.create(config)
 
@@ -479,7 +485,7 @@ class AdminGroupsImages(HTTPSupport):
 
         # assign the connected group
         config['global'] = False
-        config['groups'] = [dict(id=group_id)]
+        config['groups'] = dict(connect=[dict(id=group_id)])
 
         return self.primehub.admin_images.create(config)
 

--- a/primehub/admin_groups.py
+++ b/primehub/admin_groups.py
@@ -364,7 +364,7 @@ class AdminGroupsInstanceTypes(HTTPSupport):
         """
         return self._instancetype_group_in_and_out(group_id, instancetype_id, False)
 
-    @cmd(name='connect-image', description='Make the instanceType join the group')
+    @cmd(name='connect-instancetype', description='Make the instanceType join the group')
     def connect_instancetype(self, group_id: str, instancetype_id: str) -> Dict:
         """
         Make the instanceType join the group

--- a/primehub/admin_groups.py
+++ b/primehub/admin_groups.py
@@ -327,8 +327,8 @@ class AdminGroupsImages(HTTPSupport):
 
 class AdminGroupsUsers(HTTPSupport):
 
-    @cmd(name='add-user', description='Add the user to the group', optionals=[('enable_group_admin', toggle_flag)])
-    def add_user(self, group_id: str, user_id: str, **kwargs):
+    @cmd(name='connect-user', description='Add the user to the group', optionals=[('enable_group_admin', toggle_flag)])
+    def connect_user(self, group_id: str, user_id: str, **kwargs):
         """
         Add the user to the group
 
@@ -382,9 +382,9 @@ class AdminGroupsUsers(HTTPSupport):
         # but we only care if the user was added successfully
         return results['data']['updateGroup']
 
-    @cmd(name='remove-user', description='Remove the user from the group',
+    @cmd(name='disconnect-user', description='Remove the user from the group',
          optionals=[('disable_group_admin', toggle_flag)])
-    def remove_user(self, group_id: str, user_id: str, **kwargs):
+    def disconnect_user(self, group_id: str, user_id: str, **kwargs):
         """
         Add the user to the group
 

--- a/primehub/admin_images.py
+++ b/primehub/admin_images.py
@@ -293,6 +293,7 @@ class AdminImages(Helpful, Module):
           }
         }
         """
+
         results = self.request({'where': {'id': id}}, query)
         if 'data' not in results:
             return results

--- a/primehub/extras/templates/examples/admin/groups.md
+++ b/primehub/extras/templates/examples/admin/groups.md
@@ -118,14 +118,14 @@ id                                    username    group_admin
 c634f8c9-d22e-4ead-bfa2-21ed018f6029  phadmin     True
 ```
 
-`add-user` and `remove-user` have same arguments to add or remove a user from the group,
+`connect-user` and `disconnect-user` have same arguments to add or remove a user from the group,
 but they are also do the group-admin enabling and disable.
 
 You can add an existing user with `--enable_group_admin` to added the group admin permission:
 
 ```
-$ primehub admin groups add-user 149f4cb6-e8d1-44e8-93d4-3a77f46ac682 698da31d-2ef8-476d-9d56-6275a949402c --enable_group_admin
+$ primehub admin groups connect-user 149f4cb6-e8d1-44e8-93d4-3a77f46ac682 698da31d-2ef8-476d-9d56-6275a949402c --enable_group_admin
 ```
 
-The permission can disable with `remove-user` and `--disable_group_admin`. When `--disable_group_admin` has set,
+The permission can disable with `disconnect-user` and `--disable_group_admin`. When `--disable_group_admin` has set,
 removal operation will only remove the permission not the user.


### PR DESCRIPTION
## TODOs

- [x] rename operations in users
- [x] images
- [x] instancetypes
- [x] volumes

## Add image related commands
* create-image
* connect-image
* disconnect-image
* list-images



```
$ primehub admin groups
Usage:
  primehub admin groups <command>

Manage groups

Available Commands:
  add-user             Add the user to the group
  connect-image        Make the image join the group
  create               Create a group
  create-image         Add the image to the group
  delete               Delete the group by id
  disconnect-image     Make the image leave the group
  get                  Get the group info by id
  list                 List groups
  list-images          List images in the group
  list-users           List users in the group
  remove-user          Remove the user from the group
  update               Update the group

Options:
  -h, --help           Show the help

Global Options:
  --config CONFIG      Change the path of the config file (Default: ~/.primehub/config.json)
  --endpoint ENDPOINT  Override the GraphQL API endpoint
  --token TOKEN        Override the API Token
  --group GROUP        Override the current group
  --json               Output the json format (output human-friendly format by default)
```