### PR TITLE
Add reports list and download commands

### DIFF
--- a/docs/CLI/admin/reports.md
+++ b/docs/CLI/admin/reports.md
@@ -1,0 +1,62 @@
+
+# <ADMIN> Primehub Reports
+
+```
+Usage: 
+  primehub admin reports <command>
+
+Get reports
+
+Available Commands:
+  download             Download a report by url
+  list                 List reports
+
+Options:
+  -h, --help           Show the help
+
+Global Options:
+  --config CONFIG      Change the path of the config file (Default: ~/.primehub/config.json)
+  --endpoint ENDPOINT  Override the GraphQL API endpoint
+  --token TOKEN        Override the API Token
+  --group GROUP        Override the current group
+  --json               Output the json format (output human-friendly format by default)
+
+```
+
+
+### download
+
+Download a report by url
+
+
+```
+primehub admin reports download <url>
+```
+
+* url: The report url.
+ 
+
+* *(optional)* dest: The local path to save the report csv file
+
+
+
+
+### list
+
+List reports
+
+
+```
+primehub admin reports list
+```
+ 
+
+* *(optional)* page: the page of all data
+
+
+
+ 
+
+## Examples
+
+TBD: please write example for [reports]

--- a/docs/CLI/admin/reports.md
+++ b/docs/CLI/admin/reports.md
@@ -59,4 +59,33 @@ primehub admin reports list
 
 ## Examples
 
-TBD: please write example for [reports]
+
+### Reports list and download
+
+List reports
+
+```
+$ primehub admin reports list
+primehub admin reports list --json | jq .
+[
+  {
+    "id": "2022/12",
+    "summaryUrl": "https://primehub-python-sdk.primehub.io/api/report/monthly/2022/12",
+    "detailedUrl": "https://primehub-python-sdk.primehub.io/api/report/monthly/details/2022/12"
+  }
+]
+```
+
+Download a report by url:
+
+```
+$ primehub admin reports download https://primehub-python-sdk.primehub.io/api/report/monthly/details/2022/12
+filename:       202212_details.csv
+```
+
+Download a report with `--dest` to change the download path:
+
+```
+$ primehub admin reports download https://primehub-python-sdk.primehub.io/api/report/monthly/2022/12 --dest foo/bar/202212.csv
+filename:       /home/primehub/foo/bar/202212.csv
+```

--- a/primehub/__init__.py
+++ b/primehub/__init__.py
@@ -226,6 +226,7 @@ class PrimeHub(object):
         self.register_admin_command('admin_users', 'AdminUsers', 'users')
         self.register_admin_command('admin_groups', 'AdminGroups', 'groups')
         self.register_admin_command('admin_secrets', 'AdminSecrets', 'secrets')
+        self.register_admin_command('admin_reports', 'AdminReport', 'reports')
 
         # initial
         self._ensure_config_details(config)

--- a/primehub/admin_reports.py
+++ b/primehub/admin_reports.py
@@ -50,7 +50,7 @@ class AdminReport(Helpful, Module):
 
         def prepare_directory(dest: str):
             try:
-                os.truncate(dest)
+                os.truncate(dest, 0)
                 return
             except BaseException:
                 pass
@@ -77,11 +77,9 @@ class AdminReport(Helpful, Module):
         """
 
         query = """
-        query UsageReportQuery($usageReportPage: Int, $usageReportOrderBy: UsageReportOrderByInput, $usageReportWhere: UsageReportWhereInput) {
+        query UsageReportQuery($usageReportPage: Int) {
           usageReport: usageReportsConnection(
             page: $usageReportPage
-            orderBy: $usageReportOrderBy
-            where: $usageReportWhere
           ) {
             edges {
               cursor

--- a/primehub/admin_reports.py
+++ b/primehub/admin_reports.py
@@ -1,0 +1,125 @@
+import os.path
+from typing import Iterator
+
+from primehub import Helpful, Module, PrimeHubException, cmd
+
+
+class AdminReport(Helpful, Module):
+
+    @cmd(name='download', description='Download a report by url', optionals=[('dest', str)])
+    def download(self, url, **kwargs):
+        """
+        Download a report csv file from the given url.
+
+        It will convert the URI to filename by default. For example, there are summary url and details url
+        * https://primehub-python-sdk.primehub.io/api/report/monthly/2022/12
+        * https://primehub-python-sdk.primehub.io/api/report/monthly/details/2022/12
+
+        Will save to
+        * 202212.csv
+        * 202212_details.csv
+
+        If you give a dest, it will use the given dest as the filename.
+
+        :type url: str
+        :param url: The report url.
+
+        :type dest: str
+        :param dest: The local path to save the report csv file
+
+        :type recusive: bool
+        :param recusive: Copy recursively, it works when a path is a directory.
+        """
+
+        def convert_to_filename(url, segment_str, dest):
+            if dest:
+                return os.path.abspath(dest)
+            filename = url.split(segment_str)[1].replace('/', '')
+            if 'details' in segment_str:
+                return f'{filename}_details.csv'
+            return os.path.join(os.getcwd(), f'{filename}.csv')
+
+        dest = kwargs.get('dest')
+        filename = None
+        if '/monthly/details/' in url:
+            filename = convert_to_filename(url, '/monthly/details/', dest)
+        elif '/monthly/' in url:
+            filename = convert_to_filename(url, '/monthly/', dest)
+        else:
+            raise PrimeHubException(f'invalid url: {url}')
+
+        def prepare_directory(dest: str):
+            try:
+                os.truncate(dest)
+                return
+            except BaseException:
+                pass
+
+            try:
+                os.makedirs(os.path.dirname(dest), exist_ok=True)
+            except BaseException:
+                pass
+
+        prepare_directory(filename)
+        self.request_file(url, filename)
+        return dict(filename=filename)
+
+    @cmd(name='list', description='List reports', optionals=[('page', int)])
+    def list(self, **kwargs) -> Iterator:
+        """
+        List reports
+
+        :type page: int
+        :param page: the page of all data
+
+        :rtype Iterator
+        :return user iterator
+        """
+
+        query = """
+        query UsageReportQuery($usageReportPage: Int, $usageReportOrderBy: UsageReportOrderByInput, $usageReportWhere: UsageReportWhereInput) {
+          usageReport: usageReportsConnection(
+            page: $usageReportPage
+            orderBy: $usageReportOrderBy
+            where: $usageReportWhere
+          ) {
+            edges {
+              cursor
+              node {
+                id
+                summaryUrl
+                detailedUrl
+              }
+            }
+            pageInfo {
+              currentPage
+              totalPage
+            }
+          }
+        }
+        """
+
+        variables = {'usageReportPage': 1}
+
+        page = kwargs.get('page', 1)
+        if page >= 1:
+            variables['usageReportPage'] = int(page)
+            results = self.request(variables, query)
+            if results['data']['usageReport']['edges']:
+                for e in results['data']['usageReport']['edges']:
+                    yield e['node']
+            return
+
+        page = 1
+        while True:
+            variables['usageReportPage'] = int(page)
+            results = self.request(variables, query)
+            if results['data']['users']['edges']:
+                for e in results['data']['users']['edges']:
+                    yield e['node']
+                page = page + 1
+            else:
+                break
+
+    def help_description(self):
+        return "Get reports"

--- a/primehub/admin_reports.py
+++ b/primehub/admin_reports.py
@@ -78,9 +78,7 @@ class AdminReport(Helpful, Module):
 
         query = """
         query UsageReportQuery($usageReportPage: Int) {
-          usageReport: usageReportsConnection(
-            page: $usageReportPage
-          ) {
+          usageReport: usageReportsConnection(page: $usageReportPage) {
             edges {
               cursor
               node {

--- a/primehub/extras/templates/examples/admin/reports.md
+++ b/primehub/extras/templates/examples/admin/reports.md
@@ -1,0 +1,30 @@
+
+### Reports list and download
+
+List reports
+
+```
+$ primehub admin reports list
+primehub admin reports list --json | jq .
+[
+  {
+    "id": "2022/12",
+    "summaryUrl": "https://primehub-python-sdk.primehub.io/api/report/monthly/2022/12",
+    "detailedUrl": "https://primehub-python-sdk.primehub.io/api/report/monthly/details/2022/12"
+  }
+]
+```
+
+Download a report by url:
+
+```
+$ primehub admin reports download https://primehub-python-sdk.primehub.io/api/report/monthly/details/2022/12
+filename:       202212_details.csv
+```
+
+Download a report with `--dest` to change the download path:
+
+```
+$ primehub admin reports download https://primehub-python-sdk.primehub.io/api/report/monthly/2022/12 --dest foo/bar/202212.csv
+filename:       /home/primehub/foo/bar/202212.csv
+```


### PR DESCRIPTION
Add reports commands

```
$ primehub admin reports
Usage:
  primehub admin reports <command>

Get reports

Available Commands:
  download             Download a report by url
  list                 List reports

Options:
  -h, --help           Show the help

Global Options:
  --config CONFIG      Change the path of the config file (Default: ~/.primehub/config.json)
  --endpoint ENDPOINT  Override the GraphQL API endpoint
  --token TOKEN        Override the API Token
  --group GROUP        Override the current group
  --json               Output the json format (output human-friendly format by default)
```

---

List reports

```json
$ primehub admin reports list --json | jq .
[
  {
    "id": "2022/12",
    "summaryUrl": "http://ec2-18-181-237-123.ap-northeast-1.compute.amazonaws.com/api/report/monthly/2022/12",
    "detailedUrl": "http://ec2-18-181-237-123.ap-northeast-1.compute.amazonaws.com/api/report/monthly/details/2022/12"
  }
]
```

Download a report

```
$ primehub admin reports download http://ec2-18-181-237-123.ap-northeast-1.compute.amazonaws.com/api/report/monthly/2022/12
filename:       /Users/qrtt1/temp/primehub-python-sdk/202212.csv

$ primehub admin reports download http://ec2-18-181-237-123.ap-northeast-1.compute.amazonaws.com/api/report/monthly/details/2022/12
filename:       202212_details.csv

```