### PR TITLE
Add mlflow config functions to groups

### DIFF
--- a/docs/CLI/groups.md
+++ b/docs/CLI/groups.md
@@ -169,3 +169,47 @@ id                                    name     displayName     quotaCpu      quo
 ------------------------------------  -------  --------------  ----------  ----------  -------------  -----------------  -----------------  --------------------
 2b080113-e2f1-4b1b-a6ef-eb0ca5e2f376  phusers  primehub users                       0                                                    0
 ```
+
+### MLflow configuration
+
+To get MLflow configuration of current group, use `get-mlflow` command:
+
+```
+primehub groups get-mlflow
+```
+
+```
+trackingUri:    http://app-mlflow-xyzab:5000
+uiUrl:          https://primehub-python-sdk.primehub.io/console/apps/mlflow-xyzab
+trackingEnvs:   [{'name': 'NAME1', 'value': 'value1'}]
+artifactEnvs:   []
+```
+
+To set MLflow configuration, use `set-mlflow` command:
+
+```bash
+primehub group set-mlflow <<EOF
+{
+  "tracking_uri": "http://app-mlflow-xyzab:5000",
+  "ui_uri": "https://primehub-python-sdk.primehub.io/console/apps/mlflow-xyzab",
+  "artifactEnvs": [
+    { "name": "NAME1", "value": "value1" },
+    { "name": "NAME2", "value": "value2" }
+  ]
+}
+EOF
+```
+
+* The `tracking_uri` field is required for `set-mlflow` command
+
+You can also set MLflow configuration from a json file:
+
+```
+primehub group set-mlflow --file /tmp/mlflow.json
+```
+
+To clear MLflow for current group, use `unset-mlflow` command:
+
+```
+primehub groups unset-mlflow
+```

--- a/docs/CLI/groups.md
+++ b/docs/CLI/groups.md
@@ -10,9 +10,12 @@ Get a group or list groups
 Available Commands:
   add-user             Add a user to a group by id
   get                  Get group by name
+  get-mlflow           Get MLflow config from current group
   list                 List groups
   list-users           List users in the group by id
   remove-user          Remove a user from a group by id
+  set-mlflow           Set MLflow config to current group
+  unset-mlflow         Unset MLflow config from current group
 
 Options:
   -h, --help           Show the help
@@ -59,6 +62,19 @@ primehub groups get <group_name>
 
 
 
+### get-mlflow
+
+Get MLflow config from current group
+
+
+```
+primehub groups get-mlflow
+```
+ 
+
+
+
+
 ### list
 
 List groups
@@ -98,6 +114,34 @@ primehub groups remove-user <group_id> <user_id>
 
 * group_id: group id
 * user_id: user id
+ 
+
+
+
+
+### set-mlflow
+
+Set MLflow config to current group
+
+
+```
+primehub groups set-mlflow
+```
+ 
+
+* *(optional)* file: The file path of MLflow configuration
+
+
+
+
+### unset-mlflow
+
+Unset MLflow config from current group
+
+
+```
+primehub groups unset-mlflow
+```
  
 
 

--- a/docs/CLI/groups.md
+++ b/docs/CLI/groups.md
@@ -10,12 +10,12 @@ Get a group or list groups
 Available Commands:
   add-user             Add a user to a group by id
   get                  Get group by name
-  get-mlflow           Get MLflow config from current group
+  get-mlflow           Get MLflow config from a group by id
   list                 List groups
   list-users           List users in the group by id
   remove-user          Remove a user from a group by id
-  set-mlflow           Set MLflow config to current group
-  unset-mlflow         Unset MLflow config from current group
+  set-mlflow           Set MLflow config to a group by id
+  unset-mlflow         Unset MLflow config from a group by id
 
 Options:
   -h, --help           Show the help
@@ -64,12 +64,14 @@ primehub groups get <group_name>
 
 ### get-mlflow
 
-Get MLflow config from current group
+Get MLflow config from a group by id
 
 
 ```
-primehub groups get-mlflow
+primehub groups get-mlflow <group_id>
 ```
+
+* group_id: group id
  
 
 
@@ -121,12 +123,14 @@ primehub groups remove-user <group_id> <user_id>
 
 ### set-mlflow
 
-Set MLflow config to current group
+Set MLflow config to a group by id
 
 
 ```
-primehub groups set-mlflow
+primehub groups set-mlflow <group_id>
 ```
+
+* group_id: group id
  
 
 * *(optional)* file: The file path of MLflow configuration
@@ -136,12 +140,14 @@ primehub groups set-mlflow
 
 ### unset-mlflow
 
-Unset MLflow config from current group
+Unset MLflow config from a group by id
 
 
 ```
-primehub groups unset-mlflow
+primehub groups unset-mlflow <group_id>
 ```
+
+* group_id: group id
  
 
 
@@ -172,10 +178,10 @@ id                                    name     displayName     quotaCpu      quo
 
 ### MLflow configuration
 
-To get MLflow configuration of current group, use `get-mlflow` command:
+To get MLflow configuration of a group, use `get-mlflow` command:
 
 ```
-primehub groups get-mlflow
+primehub groups get-mlflow <group_id>
 ```
 
 ```
@@ -188,7 +194,7 @@ artifactEnvs:   []
 To set MLflow configuration, use `set-mlflow` command:
 
 ```bash
-primehub group set-mlflow <<EOF
+primehub group set-mlflow <group_id> <<EOF
 {
   "tracking_uri": "http://app-mlflow-xyzab:5000",
   "ui_uri": "https://primehub-python-sdk.primehub.io/console/apps/mlflow-xyzab",
@@ -205,11 +211,11 @@ EOF
 You can also set MLflow configuration from a json file:
 
 ```
-primehub group set-mlflow --file /tmp/mlflow.json
+primehub group set-mlflow <group_id> --file /tmp/mlflow.json
 ```
 
-To clear MLflow for current group, use `unset-mlflow` command:
+To clear MLflow for a group, use `unset-mlflow` command:
 
 ```
-primehub groups unset-mlflow
+primehub groups unset-mlflow <group_id>
 ```

--- a/primehub/apps.py
+++ b/primehub/apps.py
@@ -46,6 +46,7 @@ _query_ph_applications = query = """
               description
             }
             appTemplate {
+              id
               name
               docLink
               description

--- a/primehub/extras/templates/examples/groups.md
+++ b/primehub/extras/templates/examples/groups.md
@@ -20,10 +20,10 @@ id                                    name     displayName     quotaCpu      quo
 
 ### MLflow configuration
 
-To get MLflow configuration of current group, use `get-mlflow` command:
+To get MLflow configuration of a group, use `get-mlflow` command:
 
 ```
-primehub groups get-mlflow
+primehub groups get-mlflow <group_id>
 ```
 
 ```
@@ -36,7 +36,7 @@ artifactEnvs:   []
 To set MLflow configuration, use `set-mlflow` command:
 
 ```bash
-primehub group set-mlflow <<EOF
+primehub group set-mlflow <group_id> <<EOF
 {
   "tracking_uri": "http://app-mlflow-xyzab:5000",
   "ui_uri": "https://primehub-python-sdk.primehub.io/console/apps/mlflow-xyzab",
@@ -53,11 +53,11 @@ EOF
 You can also set MLflow configuration from a json file:
 
 ```
-primehub group set-mlflow --file /tmp/mlflow.json
+primehub group set-mlflow <group_id> --file /tmp/mlflow.json
 ```
 
-To clear MLflow for current group, use `unset-mlflow` command:
+To clear MLflow for a group, use `unset-mlflow` command:
 
 ```
-primehub groups unset-mlflow
+primehub groups unset-mlflow <group_id>
 ```

--- a/primehub/extras/templates/examples/groups.md
+++ b/primehub/extras/templates/examples/groups.md
@@ -49,6 +49,17 @@ EOF
 ```
 
 * The `tracking_uri` field is required for `set-mlflow` command
+* If `jq` command installed, you can use `jq` to obtain `tracking_uri` easily:
+    ```
+    primehub apps list --json | jq -r '.[] | select(.appTemplate.id == "mlflow") | {"id": .id, "name": .displayName, "tracking_uri": (.svcEndpoints[0] | tostring | ("http://" + .)) }'
+    ```
+    ```
+    {
+      "id": "mlflow-xyzab",
+      "name": "mlflow-infuseai",
+      "tracking_uri": "http://app-mlflow-xyzab:5000"
+    }
+    ```
 
 You can also set MLflow configuration from a json file:
 

--- a/primehub/extras/templates/examples/groups.md
+++ b/primehub/extras/templates/examples/groups.md
@@ -18,3 +18,46 @@ id                                    name     displayName     quotaCpu      quo
 2b080113-e2f1-4b1b-a6ef-eb0ca5e2f376  phusers  primehub users                       0                                                    0
 ```
 
+### MLflow configuration
+
+To get MLflow configuration of current group, use `get-mlflow` command:
+
+```
+primehub groups get-mlflow
+```
+
+```
+trackingUri:    http://app-mlflow-xyzab:5000
+uiUrl:          https://primehub-python-sdk.primehub.io/console/apps/mlflow-xyzab
+trackingEnvs:   [{'name': 'NAME1', 'value': 'value1'}]
+artifactEnvs:   []
+```
+
+To set MLflow configuration, use `set-mlflow` command:
+
+```bash
+primehub group set-mlflow <<EOF
+{
+  "tracking_uri": "http://app-mlflow-xyzab:5000",
+  "ui_uri": "https://primehub-python-sdk.primehub.io/console/apps/mlflow-xyzab",
+  "artifactEnvs": [
+    { "name": "NAME1", "value": "value1" },
+    { "name": "NAME2", "value": "value2" }
+  ]
+}
+EOF
+```
+
+* The `tracking_uri` field is required for `set-mlflow` command
+
+You can also set MLflow configuration from a json file:
+
+```
+primehub group set-mlflow --file /tmp/mlflow.json
+```
+
+To clear MLflow for current group, use `unset-mlflow` command:
+
+```
+primehub groups unset-mlflow
+```

--- a/primehub/groups.py
+++ b/primehub/groups.py
@@ -199,11 +199,13 @@ defaults to False
             return results
         return results['data']['updateGroup']
 
-    @cmd(name='set-mlflow', description='Set MLflow config to current group', optionals=[('file', file_flag)])
-    def _set_mlflow(self, **kwargs):
+    @cmd(name='set-mlflow', description='Set MLflow config to a group by id', optionals=[('file', file_flag)])
+    def _set_mlflow(self, group_id: str, **kwargs):
         """
-        Set MLflow configuration to current group
+        Set MLflow configuration to a group by id
 
+        :type group_id: str
+        :param group_id: group id
         :type file: str
         :param file: The file path of MLflow configuration
         """
@@ -222,12 +224,14 @@ defaults to False
                                     "\n\nExample:\n" +
                                     json.dumps(json.loads(example), indent=2) +
                                     f"\n\n{field_help}\n")
-        return self.set_mlflow(config)
+        return self.set_mlflow(group_id, config)
 
-    def set_mlflow(self, config: dict):
+    def set_mlflow(self, group_id: str, config: dict):
         """
-        Set MLflow configuration to current group
+        Set MLflow configuration to a group by id
 
+        :type group_id: str
+        :param group_id: group id
         :type config: dict
         :param config: The content of MLflow configuration
         """
@@ -241,14 +245,17 @@ defaults to False
         if not data['trackingUri']:
             raise PrimeHubException("'tracking_uri' is required")
 
-        results = self.request({'where': {'id': self.group_id}, 'data': data}, query)
+        results = self.request({'where': {'id': group_id}, 'data': data}, query)
         if 'data' not in results:
             return results
 
-    @cmd(name='unset-mlflow', description='Unset MLflow config from current group')
-    def unset_mlflow(self):
+    @cmd(name='unset-mlflow', description='Unset MLflow config from a group by id')
+    def unset_mlflow(self, group_id: str):
         """
-        Unset MLflow configuration from current group
+        Unset MLflow configuration from a group by id
+
+        :type group_id: str
+        :param group_id: group id
         """
         query = _mutation_mlflow
         data = {
@@ -257,15 +264,17 @@ defaults to False
             "trackingEnvs": [],
             "artifactEnvs": [],
         }
-        results = self.request({'where': {'id': self.group_id}, 'data': data}, query)
+        results = self.request({'where': {'id': group_id}, 'data': data}, query)
         if 'data' not in results:
             return results
 
-    @cmd(name='get-mlflow', description='Get MLflow config from current group')
-    def get_mlflow(self):
+    @cmd(name='get-mlflow', description='Get MLflow config from a group by id')
+    def get_mlflow(self, group_id: str):
         """
-        Get MLflow configuration from current group
+        Get MLflow configuration from a group by id
 
+        :type group_id: str
+        :param group_id: group id
         :rtype dict
         :return MLflow configuration
         """
@@ -289,7 +298,7 @@ defaults to False
           }
         }
         """
-        results = self.request({'where': {'id': self.group_id}}, query)
+        results = self.request({'where': {'id': group_id}}, query)
         if 'data' not in results:
             return results
         return results['data']['group']['mlflow']

--- a/primehub/groups.py
+++ b/primehub/groups.py
@@ -26,6 +26,7 @@ mutation UpdateGroupMLflowConfig($where: GroupWhereUniqueInput!, $data: GroupUpd
 }
 """
 
+
 class Groups(Helpful, Module):
     """
     List effective groups or get a group entry from the list
@@ -219,7 +220,7 @@ defaults to False
               "artifact_envs":[{"name":"key1","value":"value1"}]
             }
             """.strip()
-            field_help = f"""* 'tracking_uri' field is required"""
+            field_help = "* 'tracking_uri' field is required"
             raise PrimeHubException('MLflow configuration is required.' +
                                     "\n\nExample:\n" +
                                     json.dumps(json.loads(example), indent=2) +
@@ -258,7 +259,7 @@ defaults to False
         :param group_id: group id
         """
         query = _mutation_mlflow
-        data = {
+        data: Dict[str, Any] = {
             "trackingUri": None,
             "uiUrl": None,
             "trackingEnvs": [],


### PR DESCRIPTION
Signed-off-by: Timothy Lee <ctiml@infuseai.io>

### MLflow configuration

To get MLflow configuration of a group, use `get-mlflow` command:

```
primehub groups get-mlflow <group_id>
```

```
trackingUri:    http://app-mlflow-xyzab:5000
uiUrl:          https://primehub-python-sdk.primehub.io/console/apps/mlflow-xyzab
trackingEnvs:   [{'name': 'NAME1', 'value': 'value1'}]
artifactEnvs:   []
```

To set MLflow configuration, use `set-mlflow` command:

```bash
primehub group set-mlflow <group_id> <<EOF
{
  "tracking_uri": "http://app-mlflow-xyzab:5000",
  "ui_uri": "https://primehub-python-sdk.primehub.io/console/apps/mlflow-xyzab",
  "artifactEnvs": [
    { "name": "NAME1", "value": "value1" },
    { "name": "NAME2", "value": "value2" }
  ]
}
EOF
```

* The `tracking_uri` field is required for `set-mlflow` command
* If `jq` command installed, you can use `jq` to obtain `tracking_uri` easily:
    ```
    primehub apps list --json | jq -r '.[] | select(.appTemplate.id == "mlflow") | {"id": .id, "name": .displayName, "tracking_uri": (.svcEndpoints[0] | tostring | ("http://" + .)) }'
    ```
    ```
    {
      "id": "mlflow-xyzab",
      "name": "mlflow-infuseai",
      "tracking_uri": "http://app-mlflow-xyzab:5000"
    }
    ```

You can also set MLflow configuration from a json file:

```
primehub group set-mlflow <group_id> --file /tmp/mlflow.json
```

To clear MLflow for a group, use `unset-mlflow` command:

```
primehub groups unset-mlflow <group_id>
```